### PR TITLE
Devel

### DIFF
--- a/demos/AVR/RT-ARDUINOUNO/Makefile
+++ b/demos/AVR/RT-ARDUINOUNO/Makefile
@@ -136,6 +136,8 @@ CFLAGS = -g$(DEBUG)
 CFLAGS += $(CDEFS)
 CFLAGS += -O$(OPT)
 CFLAGS += -funsigned-char
+CFLAGS += -fdata-sections
+CFLAGS += -ffunction-sections
 CFLAGS += -funsigned-bitfields
 CFLAGS += -fpack-struct
 CFLAGS += -fshort-enums
@@ -144,9 +146,9 @@ CFLAGS += -Wall
 CFLAGS += -Wstrict-prototypes
 #CFLAGS += -mshort-calls
 #CFLAGS += -fno-unit-at-a-time
-#CFLAGS += -Wundef
-#CFLAGS += -Wunreachable-code
-#CFLAGS += -Wsign-compare
+CFLAGS += -Wundef
+CFLAGS += -Wunreachable-code
+CFLAGS += -Wsign-compare
 CFLAGS += -Wa,-adhlns=$(<:%.c=$(OBJDIR)/%.lst)
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 CFLAGS += $(CSTANDARD)
@@ -163,6 +165,8 @@ CPPFLAGS = -g$(DEBUG)
 CPPFLAGS += $(CPPDEFS)
 CPPFLAGS += -O$(OPT)
 CPPFLAGS += -funsigned-char
+CPPFLAGS += -fdata-sections
+CPPFLAGS += -ffunction-sections
 CPPFLAGS += -funsigned-bitfields
 CPPFLAGS += -fpack-struct
 CPPFLAGS += -fshort-enums
@@ -172,8 +176,8 @@ CFLAGS += -Wundef
 #CPPFLAGS += -mshort-calls
 #CPPFLAGS += -fno-unit-at-a-time
 #CPPFLAGS += -Wstrict-prototypes
-#CPPFLAGS += -Wunreachable-code
-#CPPFLAGS += -Wsign-compare
+CPPFLAGS += -Wunreachable-code
+CPPFLAGS += -Wsign-compare
 CPPFLAGS += -Wa,-adhlns=$(<:%.cpp=$(OBJDIR)/%.lst)
 CPPFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 #CPPFLAGS += $(CSTANDARD)
@@ -236,7 +240,7 @@ EXTMEMOPTS =
 #  -Wl,...:     tell GCC to pass this to linker.
 #    -Map:      create map file
 #    --cref:    add cross reference to  map file
-LDFLAGS = -Wl,-Map=$(TARGET).map,--cref
+LDFLAGS = -Wl,-Map=$(TARGET).map,--cref,--gc-sections
 LDFLAGS += $(EXTMEMOPTS)
 LDFLAGS += $(patsubst %,-L%,$(EXTRALIBDIRS))
 LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)

--- a/demos/AVR/RT-ARDUINOUNO/Makefile
+++ b/demos/AVR/RT-ARDUINOUNO/Makefile
@@ -254,7 +254,7 @@ LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)
 # Type: avrdude -c ?
 # to get a full listing.
 #
-AVRDUDE_PROGRAMMER = avrisp2 
+AVRDUDE_PROGRAMMER = dragon_isp
 
 # com1 = serial port. Use lpt1 to connect to parallel port.
 AVRDUDE_PORT = /dev/tty.usbmodem00034091
@@ -277,12 +277,12 @@ AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
 #AVRDUDE_VERBOSE = -v -v
 
 AVRDUDE_FLAGS = -p $(MCU)
-AVRDUDE_FLAGS += -P $(AVRDUDE_PORT)
-AVRDUDE_FLAGS += -b 57600
+#AVRDUDE_FLAGS += -P $(AVRDUDE_PORT)
+#AVRDUDE_FLAGS += -b 57600
 AVRDUDE_FLAGS += -c $(AVRDUDE_PROGRAMMER)
 AVRDUDE_FLAGS += $(AVRDUDE_NO_VERIFY)
 AVRDUDE_FLAGS += $(AVRDUDE_VERBOSE)
-AVRDUDE_FLAGS += $(AVRDUDE_ERASE_COUNTER)
+#AVRDUDE_FLAGS += $(AVRDUDE_ERASE_COUNTER)
 
 #---------------- Debugging Options ----------------
 

--- a/demos/AVR/RT-ARDUINOUNO/halconf.h
+++ b/demos/AVR/RT-ARDUINOUNO/halconf.h
@@ -38,6 +38,13 @@
 #endif
 
 /**
+ * @brief   Enables the PC subsystem.
+ */
+#if !defined(HAL_USE_PC) || defined(__DOXYGEN__)
+#define HAL_USE_PC                  TRUE
+#endif
+
+/**
  * @brief   Enables the PAL subsystem.
  */
 #if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
@@ -69,7 +76,7 @@
  * @brief   Enables the EXT subsystem.
  */
 #if !defined(HAL_USE_EXT) || defined(__DOXYGEN__)
-#define HAL_USE_EXT                 FALSE
+#define HAL_USE_EXT                 TRUE
 #endif
 
 /**

--- a/demos/AVR/RT-ARDUINOUNO/mcuconf.h
+++ b/demos/AVR/RT-ARDUINOUNO/mcuconf.h
@@ -81,4 +81,15 @@
 #define AVR_SPI_USE_SPI1                   FALSE
 #define AVR_SPI_USE_16BIT_POLLED_EXCHANGE  FALSE
 
+/*
+ * EXT driver system settings.
+ */
+#define AVR_EXT_USE_EXT1                    TRUE
+
+/*
+ * PC driver system settings.
+ */
+#define AVR_PC_USE_PC1                      TRUE
+
+
 #endif /* _MCUCONF_H_ */

--- a/os/hal/hal.mk
+++ b/os/hal/hal.mk
@@ -40,6 +40,9 @@ endif
 ifneq ($(findstring HAL_USE_PAL TRUE,$(HALCONF)),)
 HALSRC += $(CHIBIOS)/os/hal/src/pal.c
 endif
+ifneq ($(findstring HAL_USE_PC TRUE,$(HALCONF)),)
+HALSRC += $(CHIBIOS)/os/hal/src/pc.c
+endif
 ifneq ($(findstring HAL_USE_PWM TRUE,$(HALCONF)),)
 HALSRC += $(CHIBIOS)/os/hal/src/pwm.c
 endif
@@ -79,6 +82,7 @@ HALSRC = $(CHIBIOS)/os/hal/src/hal.c \
          $(CHIBIOS)/os/hal/src/mac.c \
          $(CHIBIOS)/os/hal/src/mmc_spi.c \
          $(CHIBIOS)/os/hal/src/pal.c \
+         $(CHIBIOS)/os/hal/src/pc.c \
          $(CHIBIOS)/os/hal/src/pwm.c \
          $(CHIBIOS)/os/hal/src/rtc.c \
          $(CHIBIOS)/os/hal/src/sdc.c \

--- a/os/hal/include/hal.h
+++ b/os/hal/include/hal.h
@@ -53,6 +53,7 @@
 #include "icu.h"
 #include "mac.h"
 #include "mii.h"
+#include "pc.h"
 #include "pwm.h"
 #include "rtc.h"
 #include "serial.h"

--- a/os/hal/include/pc.h
+++ b/os/hal/include/pc.h
@@ -1,0 +1,114 @@
+/*
+    AVR Pin Change driver for ChibiOS
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    pc.h
+ * @brief   Pin Change Driver macros and structures.
+ *
+ * @addtogroup PC
+ * @{
+ */
+
+#ifndef _PC_H_
+#define _PC_H_
+
+#if (HAL_USE_PC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver state machine possible states.
+ */
+typedef enum {
+  PC_UNINIT = 0,                   /**< Not initialized.                   */
+  PC_STOP = 1,                     /**< Stopped.                           */
+  PC_ACTIVE = 2                    /**< Active.                            */
+} pcstate_t;
+
+/**
+ * @brief   Type of a structure representing a PC driver.
+ */
+typedef struct PCDriver PCDriver;
+
+#include "pc_lld.h"
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @name    Macro Functions
+ * @{
+ */
+/**
+ * @brief   Enables a PC channel.
+ *
+ * @param[in] pcp      pointer to the @p PCDriver object
+ * @param[in] channel   channel to be enabled
+ *
+ * @iclass
+ */
+#define pcChannelEnableI(pcp, channel) pc_lld_channel_enable(pcp, channel)
+
+/**
+ * @brief   Disables a PC channel.
+ *
+ * @param[in] pcp      pointer to the @p PCDriver object
+ * @param[in] channel   channel to be disabled
+ *
+ * @iclass
+ */
+#define pcChannelDisableI(pcp, channel) pc_lld_channel_disable(pcp, channel)
+
+/** @} */
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void pcInit(void);
+  void pcObjectInit(PCDriver *pcp);
+  void pcStart(PCDriver *pcp, const PCConfig *config);
+  void pcStop(PCDriver *pcp);
+  void pcChannelEnable(PCDriver *pcp, pcchannel_t channel);
+  void pcChannelDisable(PCDriver *pcp, pcchannel_t channel);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_PC == TRUE */
+
+#endif /* _PC_H_ */
+
+/** @} */

--- a/os/hal/ports/AVR/ext_lld.c
+++ b/os/hal/ports/AVR/ext_lld.c
@@ -1,0 +1,193 @@
+/*
+    EXT Low Level Driver for ChibiOS
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ext_lld.c
+ * @brief   AVR EXT subsystem low level driver source.
+ *
+ * @addtogroup EXT
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_EXT == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#define EXT_EICRA_LOW_LEVEL    0
+#define EXT_EICRA_BOTH_EDGES   1
+#define EXT_EICRA_FALLING_EDGE 2
+#define EXT_EICRA_RISING_EDGE  3
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   EXT1 driver identifier.
+ */
+#if (AVR_EXT_USE_EXT1 == TRUE) || defined(__DOXYGEN__)
+EXTDriver EXTD1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if AVR_EXT_USE_EXT1 || defined(__DOXYGEN__)
+OSAL_IRQ_HANDLER(INT0_vect)
+{
+  OSAL_IRQ_PROLOGUE();
+  EXTD1.config->channels[EXT_INT0_CHANNEL].cb(&EXTD1, EXT_INT0_CHANNEL);
+  OSAL_IRQ_EPILOGUE();
+}
+
+OSAL_IRQ_HANDLER(INT1_vect)
+{
+  OSAL_IRQ_PROLOGUE();
+  EXTD1.config->channels[EXT_INT1_CHANNEL].cb(&EXTD1, EXT_INT1_CHANNEL);
+  OSAL_IRQ_EPILOGUE();
+}
+#endif
+
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level EXT driver initialization.
+ *
+ * @notapi
+ */
+void ext_lld_init(void) {
+
+#if AVR_EXT_USE_EXT1 == TRUE
+  /* Driver initialization.*/
+  extObjectInit(&EXTD1);
+#endif
+}
+
+/**
+ * @brief   Configures and activates the EXT peripheral.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ *
+ * @notapi
+ */
+void ext_lld_start(EXTDriver *extp) {
+
+#if AVR_EXT_USE_EXT1 == TRUE
+  uint8_t new_EICRA = 0;
+  uint8_t new_EIMSK = 0;
+  for (expchannel_t channel = 0; channel < EXT_MAX_CHANNELS; channel++) {
+    DDRD &= ~_BV(channel + 2); /* Set line as input. */
+    /* Determines the triggering condition for each channell. */
+    switch(extp->config->channels[channel].mode &
+           ~(EXT_CH_MODE_AUTOSTART | EXT_CH_MODE_INTERNAL_PULLUP)) {
+      case EXT_CH_MODE_LOW_LEVEL:
+        new_EICRA |= (EXT_EICRA_LOW_LEVEL << (2 * channel));
+        break;
+      case EXT_CH_MODE_BOTH_EDGES:
+        new_EICRA |= (EXT_EICRA_BOTH_EDGES << (2 * channel));
+        break;
+      case EXT_CH_MODE_RISING_EDGE:
+        new_EICRA |= (EXT_EICRA_RISING_EDGE << (2 * channel));
+        break;
+      case EXT_CH_MODE_FALLING_EDGE:
+        new_EICRA |= (EXT_EICRA_FALLING_EDGE << (2 * channel));
+        break;
+      default: osalDbgAssert(FALSE, "unsupported mode");
+    }
+    if (extp->config->channels[channel].mode & EXT_CH_MODE_AUTOSTART)
+      new_EIMSK |= (1 << channel);
+    /* Determines which channel must be started right away. */
+    if (extp->config->channels[channel].mode & EXT_CH_MODE_AUTOSTART)
+      new_EIMSK |= (1 << channel);
+    if (extp->config->channels[channel].mode & EXT_CH_MODE_INTERNAL_PULLUP) {
+      PORTD |= _BV(channel + 2);  /* Enable intenal pullup. */
+      MCUCR &= ~_BV(4);            /* Master pull-up enable. */
+    }
+  }
+  /* Configures the peripheral. */
+  EICRA = new_EICRA;
+  /* Enables/disables the peripheral, as requested. */
+  EIMSK = new_EIMSK;
+#endif
+
+}
+
+/**
+ * @brief   Deactivates the EXT peripheral.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ *
+ * @notapi
+ */
+void ext_lld_stop(EXTDriver *extp) {
+
+  if (extp->state == EXT_ACTIVE) {
+    /* Resets the peripheral.*/
+
+    /* Disables the peripheral.*/
+#if AVR_EXT_USE_EXT1 == TRUE
+    if (&EXTD1 == extp) {
+      EIMSK = 0;
+    }
+#endif
+  }
+}
+
+/**
+ * @brief   Enables an EXT channel.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ * @param[in] channel   channel to be enabled
+ *
+ * @notapi
+ */
+void ext_lld_channel_enable(EXTDriver *extp, expchannel_t channel) {
+  EIMSK |= (1 << channel);
+}
+
+/**
+ * @brief   Disables an EXT channel.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ * @param[in] channel   channel to be disabled
+ *
+ * @notapi
+ */
+void ext_lld_channel_disable(EXTDriver *extp, expchannel_t channel) {
+  EIMSK &= ~(1 << channel);
+  PORTD &= ~(1 << (channel + 2));
+}
+
+#endif /* HAL_USE_EXT == TRUE */
+
+/** @} */

--- a/os/hal/ports/AVR/ext_lld.h
+++ b/os/hal/ports/AVR/ext_lld.h
@@ -1,0 +1,157 @@
+/*
+    EXT Low Level Driver for ChibiOS
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ext_lld.h
+ * @brief   AVR EXT subsystem low level driver header.
+ *
+ * @addtogroup EXT
+ * @{
+ */
+
+#ifndef _EXT_LLD_H_
+#define _EXT_LLD_H_
+
+#if (HAL_USE_EXT == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Available number of EXT channels.
+ */
+#define EXT_INT0_CHANNEL    0
+#define EXT_INT1_CHANNEL    1
+#define EXT_MAX_CHANNELS    2
+
+/**
+ * @brief  Level-driven irq generation.
+ */
+#define EXT_CH_MODE_LEVELS_MASK       8U  /**< @brief Mask of levels field. */
+#define EXT_CH_MODE_LOW_LEVEL         8U  /**< @brief Trigger on Low level. */
+#define EXT_CH_MODE_INTERNAL_PULLUP  16U  /**< @brief Use internal pullup.  */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    AVR configuration options
+ * @{
+ */
+/**
+ * @brief   EXT driver enable switch.
+ * @details If set to @p TRUE the support for EXT1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(AVR_EXT_USE_EXT1) || defined(__DOXYGEN__)
+#define AVR_EXT_USE_EXT1               FALSE
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   EXT channel identifier.
+ */
+typedef uint8_t expchannel_t;
+
+/**
+ * @brief   Type of an EXT generic notification callback.
+ *
+ * @param[in] extp      pointer to the @p EXPDriver object triggering the
+ *                      callback
+ */
+typedef void (*extcallback_t)(EXTDriver *extp, expchannel_t channel);
+
+/**
+ * @brief   Channel configuration structure.
+ */
+typedef struct {
+  /**
+   * @brief Channel mode from HAL.
+   */
+  uint8_t              mode;
+  /**
+   * @brief Channel callback.
+   */
+  extcallback_t         cb;
+} EXTChannelConfig;
+
+/**
+ * @brief   Driver configuration structure.
+ * @note    It could be empty on some architectures.
+ */
+typedef struct {
+  /**
+   * @brief Channel configurations.
+   */
+  EXTChannelConfig      channels[EXT_MAX_CHANNELS];
+  /* End of the mandatory fields.*/
+} EXTConfig;
+
+/**
+ * @brief   Structure representing an EXT driver.
+ */
+struct EXTDriver {
+  /**
+   * @brief Driver state.
+   */
+  extstate_t                state;
+  /**
+   * @brief Current configuration data.
+   */
+  const EXTConfig           *config;
+  /* End of the mandatory fields.*/
+};
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (AVR_EXT_USE_EXT1 == TRUE) && !defined(__DOXYGEN__)
+extern EXTDriver EXTD1;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void ext_lld_init(void);
+  void ext_lld_start(EXTDriver *extp);
+  void ext_lld_stop(EXTDriver *extp);
+  void ext_lld_channel_enable(EXTDriver *extp, expchannel_t channel);
+  void ext_lld_channel_disable(EXTDriver *extp, expchannel_t channel);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_EXT == TRUE */
+
+#endif /* _EXT_LLD_H_ */
+
+/** @} */

--- a/os/hal/ports/AVR/pc_lld.c
+++ b/os/hal/ports/AVR/pc_lld.c
@@ -1,0 +1,264 @@
+/*
+    Pin Change Low Level Driver for ChibiOS
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    pc_lld.c
+ * @brief   AVR PC subsystem low level driver source.
+ *
+ * @addtogroup PC
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_PC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#define declare_pcint_isr(channel)                             \
+  OSAL_IRQ_HANDLER(PCINT##channel##_vect) {                    \
+    OSAL_IRQ_PROLOGUE();                                       \
+    PCD1.current_values[channel] =                             \
+      (*(PINS[channel])) & (*(PCMSK[channel]));                \
+    PCD1.config->cb[PC_INT##channel##_CHANNEL]                 \
+      (&PCD1, PC_INT##channel##_CHANNEL);                      \
+    PCD1.old_values[channel] = PCD1.current_values[channel];   \
+    OSAL_IRQ_EPILOGUE();                                       \
+  }
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   PC1 driver identifier.
+ */
+#if (AVR_PC_USE_PC1 == TRUE) || defined(__DOXYGEN__)
+PCDriver PCD1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+volatile uint8_t * const PINS[PC_MAX_PORTS] = {
+#if defined(PORTA)
+  (volatile uint8_t *const)&PINA,
+#endif
+#if defined(PORTB)
+  (volatile uint8_t *const)&PINB,
+#endif
+#if defined(PORTC)
+  (volatile uint8_t *const)&PINC,
+#endif
+#if defined(PORTD)
+  (volatile uint8_t *const)&PIND,
+#endif
+#if defined(PORTE)
+  (volatile uint8_t *const)&PINE,
+#endif
+#if defined(PORTF)
+  (volatile uint8_t *const)&PINF,
+#endif
+#if defined(PORTG)
+  (volatile uint8_t *const)&PING,
+#endif
+#if defined(PORTH)
+  (volatile uint8_t *const)&PINH,
+#endif
+#if defined(PORTI)
+  (volatile uint8_t *const)&PINI,
+#endif
+#if defined(PORTJ)
+  (volatile uint8_t *const)&PINJ,
+#endif
+};
+
+volatile uint8_t * const PCMSK[PC_MAX_PORTS] = {
+  #if 0 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK0,
+  #endif
+  #if 1 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK1,
+  #endif
+  #if 2 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK2,
+  #endif
+  #if 3 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK3,
+  #endif
+  #if 4 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK4,
+  #endif
+  #if 5 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK5,
+  #endif
+  #if 6 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK6,
+  #endif
+  #if 7 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK7,
+  #endif
+  #if 8 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK8,
+  #endif
+  #if 9 < PC_MAX_CHANNELS
+    (volatile uint8_t *const)&PCMSK9,
+  #endif
+};
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if AVR_PC_USE_PC1 || defined(__DOXYGEN__)
+  #if 0 < PC_MAX_CHANNELS
+    declare_pcint_isr(0);
+  #endif
+  #if 1 < PC_MAX_CHANNELS
+    declare_pcint_isr(1);
+  #endif
+  #if 2 < PC_MAX_CHANNELS
+    declare_pcint_isr(2);
+  #endif
+  #if 3 < PC_MAX_CHANNELS
+    declare_pcint_isr(3);
+  #endif
+  #if 4 < PC_MAX_CHANNELS
+    declare_pcint_isr(4);
+  #endif
+  #if 5 < PC_MAX_CHANNELS
+    declare_pcint_isr(5);
+  #endif
+  #if 6 < PC_MAX_CHANNELS
+    declare_pcint_isr(6);
+  #endif
+  #if 7 < PC_MAX_CHANNELS
+    declare_pcint_isr(7);
+  #endif
+  #if 8 < PC_MAX_CHANNELS
+    declare_pcint_isr(8);
+  #endif
+  #if 9 < PC_MAX_CHANNELS
+    declare_pcint_isr(9);
+  #endif
+#endif
+
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level PC driver initialization.
+ *
+ * @notapi
+ */
+void pc_lld_init(void) {
+#if AVR_PC_USE_PC1 == TRUE
+  int i;
+  /* Driver initialization.*/
+  pcObjectInit(&PCD1);
+  for (i = 0; i < PC_MAX_PORTS; i++)
+    PCD1.old_values[i] = 0;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the PC peripheral.
+ *
+ * @param[in] pcp      pointer to the @p PCDriver object
+ *
+ * @notapi
+ */
+void pc_lld_start(PCDriver *pcp) {
+
+#if AVR_PC_USE_PC1 == TRUE
+  /* Configures the peripheral. */
+  uint8_t new_PCICR = 0;
+  uint8_t i;
+  for (i = 0; i < PC_MAX_CHANNELS; i++)
+    if (pcp->config->enabled[i]) {
+        new_PCICR |= _BV(i);
+        (*(PCMSK[i])) = pcp->config->enabled[i];
+    }
+  /* Enables/disables the peripheral, as requested. */
+  PCICR = new_PCICR;
+#endif
+
+}
+
+/**
+ * @brief   Deactivates the PC peripheral.
+ *
+ * @param[in] pcp   pointer to the @p PCDriver object
+ *
+ * @notapi
+ */
+void pc_lld_stop(PCDriver *pcp) {
+
+  if (pcp->state == PC_ACTIVE) {
+    /* Resets the peripheral.*/
+
+    /* Disables the peripheral.*/
+#if AVR_PC_USE_PC1 == TRUE
+    if (&PCD1 == pcp) {
+      EIMSK = 0;
+    }
+#endif
+  }
+}
+
+/**
+ * @brief   Enables an PC channel.
+ *
+ * @param[in] pcp       pointer to the @p PCDriver object
+ * @param[in] channel   channel to be enabled
+ *
+ * @notapi
+ */
+void pc_lld_channel_enable(PCDriver *pcp, pcchannel_t channel) {
+  uint8_t index = channel / 8;
+  ((uint8_t *)(pcp->config->enabled))[index] |= _BV(channel % 8);
+  (*(PCMSK[index])) = pcp->config->enabled[index];
+  PCICR |= _BV(index);
+}
+
+/**
+ * @brief   Disables a PC channel.
+ *
+ * @param[in] pcp      pointer to the @p PCDriver object
+ * @param[in] channel  channel to be disabled
+ *
+ * @notapi
+ */
+void pc_lld_channel_disable(PCDriver *pcp, expchannel_t channel) {
+  uint8_t index = channel / 8;
+  ((uint8_t *)(pcp->config->enabled))[index] &= ~_BV(channel % 8);
+  (*(PCMSK[index])) = pcp->config->enabled[index];
+  if (!(*(PCMSK[index])))
+    PCICR &= ~_BV(index);
+}
+
+#endif /* HAL_USE_PC == TRUE */
+
+/** @} */

--- a/os/hal/ports/AVR/pc_lld.h
+++ b/os/hal/ports/AVR/pc_lld.h
@@ -1,0 +1,253 @@
+/*
+    Pin Change Low Level Driver for ChibiOS
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    pc_lld.h
+ * @brief   AVR PC subsystem low level driver header.
+ *
+ * @addtogroup PC
+ * @{
+ */
+
+#ifndef _PC_LLD_H_
+#define _PC_LLD_H_
+
+#if (HAL_USE_PC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+#if defined(PORTA)
+  #define PORTA_PRESENT 1
+  #define PORTA_INDEX   0
+#else
+  #define PORTA_PRESENT 0
+  #define PORTA_INDEX   -1
+#endif
+
+#if defined(PORTB)
+  #define PORTB_PRESENT 1
+  #define PORTB_INDEX   (PORTA_INDEX + 1)
+#else
+  #define PORTB_PRESENT 0
+  #define PORTB_INDEX   PORTA_INDEX
+#endif
+
+#if defined(PORTC)
+  #define PORTC_PRESENT 1
+  #define PORTC_INDEX   (PORTB_INDEX + 1)
+#else
+  #define PORTC_PRESENT 0
+  #define PORTC_INDEX   PORTB_INDEX
+#endif
+
+#if defined(PORTD)
+  #define PORTD_PRESENT 1
+  #define PORTD_INDEX   (PORTC_INDEX + 1)
+#else
+  #define PORTD_PRESENT 0
+  #define PORTD_INDEX   PORTC_INDEX
+#endif
+
+#if defined(PORTE)
+  #define PORTE_PRESENT 1
+  #define PORTE_INDEX   (PORTD_INDEX + 1)
+#else
+  #define PORTE_PRESENT 0
+  #define PORTE_INDEX   PORTD_INDEX
+#endif
+
+#if defined(PORTF)
+  #define PORTF_PRESENT 1
+  #define PORTF_INDEX   (PORTE_INDEX + 1)
+#else
+  #define PORTF_PRESENT 0
+  #define PORTF_INDEX   PORTE_INDEX
+#endif
+
+#if defined(PORTG)
+  #define PORTG_PRESENT 1
+  #define PORTG_INDEX   (PORTF_INDEX + 1)
+#else
+  #define PORTG_PRESENT 0
+  #define PORTG_INDEX   PORTF_INDEX
+#endif
+
+#if defined(PORTH)
+  #define PORTH_PRESENT 1
+  #define PORTH_INDEX   (PORTG_INDEX + 1)
+#else
+  #define PORTH_PRESENT 0
+  #define PORTH_INDEX   PORTG_INDEX
+#endif
+
+#if defined(PORTI)
+  #define PORTI_PRESENT 1
+  #define PORTI_INDEX   (PORTH_INDEX + 1)
+#else
+  #define PORTI_PRESENT 0
+  #define PORTI_INDEX   PORTH_INDEX
+#endif
+
+#if defined(PORTJ)
+  #define PORTJ_PRESENT 1
+  #define PORTJ_INDEX   (PORTI_INDEX + 1)
+#else
+  #define PORTJ_PRESENT 0
+  #define PORTJ_INDEX   PORTI_INDEX
+#endif
+
+#if defined(PORTK)
+  #define PORTK_PRESENT 1
+  #define PORTK_INDEX   (PORTJ_INDEX + 1)
+#else
+  #define PORTK_PRESENT 0
+  #define PORTK_INDEX   PORTJ_INDEX
+#endif
+
+/**
+ * @brief   Available number of PC channels.
+ */
+#define PC_MAX_PORTS \
+    (PORTA_PRESENT + PORTB_PRESENT + PORTC_PRESENT + PORTD_PRESENT +\
+     PORTE_PRESENT + PORTF_PRESENT + PORTG_PRESENT + PORTH_PRESENT +\
+     PORTI_PRESENT + PORTJ_PRESENT + PORTK_PRESENT)
+
+/**
+ * @brief   Available number of PC channels.
+ */
+#define PC_INT0_CHANNEL    0
+#define PC_INT1_CHANNEL    1
+#define PC_INT2_CHANNEL    2
+#define PC_INT3_CHANNEL    3
+#define PC_INT4_CHANNEL    4
+#define PC_INT5_CHANNEL    5
+#define PC_INT6_CHANNEL    6
+#define PC_INT7_CHANNEL    7
+#define PC_INT8_CHANNEL    8
+#define PC_INT9_CHANNEL    9
+#define PC_MAX_CHANNELS    PC_MAX_PORTS
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    AVR configuration options
+ * @{
+ */
+/**
+ * @brief   PC driver enable switch.
+ * @details If set to @p TRUE the support for PC1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(AVR_PC_USE_PC1) || defined(__DOXYGEN__)
+#define AVR_PC_USE_PC1               FALSE
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   PC channel identifier.
+ */
+typedef uint8_t pcchannel_t;
+
+
+/**
+ * @brief   PC port identifier.
+ */
+typedef uint8_t pcport_t;
+
+/**
+ * @brief   Type of an PC generic notification callback.
+ *
+ * @param[in] pcp      pointer to the @p EXPDriver object triggering the
+ *                     callback
+ */
+typedef void (*pccallback_t)(PCDriver *pcp, pcchannel_t channel);
+
+
+/**
+ * @brief   Driver configuration structure.
+ */
+typedef struct {
+  /**
+   * @brief Channel configurations.
+   */
+  uint8_t          enabled[PC_MAX_CHANNELS];
+  pccallback_t     cb[PC_MAX_CHANNELS];
+  /* End of the mandatory fields.*/
+} PCConfig;
+
+/**
+ * @brief   Structure representing an PC driver.
+ */
+struct PCDriver {
+  /**
+   * @brief Driver state.
+   */
+  pcstate_t        state;
+  /**
+   * @brief Current configuration data.
+   */
+  const PCConfig   *config;
+  /* End of the mandatory fields.*/
+  /**
+   * @brief previous values.
+   */
+  uint8_t           current_values[PC_MAX_PORTS];
+  uint8_t           old_values[PC_MAX_PORTS];
+};
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (AVR_PC_USE_PC1 == TRUE) && !defined(__DOXYGEN__)
+extern PCDriver PCD1;
+volatile uint8_t *const PINS[PC_MAX_PORTS];
+volatile uint8_t *const PCMSK[PC_MAX_PORTS];
+#endif
+
+#ifdef __cplusplus
+extcern "C" {
+#endif
+  void pc_lld_init(void);
+  void pc_lld_start(PCDriver *pcp);
+  void pc_lld_stop(PCDriver *pcp);
+  void pc_lld_channel_enable(PCDriver *pcp, pcchannel_t channel);
+  void pc_lld_channel_disable(PCDriver *pcp, pcchannel_t channel);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_PC == TRUE */
+
+#endif /* _PC_LLD_H_ */
+
+/** @} */

--- a/os/hal/ports/AVR/platform.mk
+++ b/os/hal/ports/AVR/platform.mk
@@ -2,6 +2,7 @@
 PLATFORMSRC = ${CHIBIOS}/os/hal/ports/AVR/hal_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/pal_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/ext_lld.c \
+              ${CHIBIOS}/os/hal/ports/AVR/pc_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/serial_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/adc_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/i2c_lld.c \

--- a/os/hal/ports/AVR/platform.mk
+++ b/os/hal/ports/AVR/platform.mk
@@ -1,6 +1,7 @@
 # List of all the AVR platform files.
 PLATFORMSRC = ${CHIBIOS}/os/hal/ports/AVR/hal_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/pal_lld.c \
+              ${CHIBIOS}/os/hal/ports/AVR/ext_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/serial_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/adc_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/i2c_lld.c \

--- a/os/hal/src/pc.c
+++ b/os/hal/src/pc.c
@@ -1,0 +1,154 @@
+/*
+    AVR Pin Change driver for ChibiOS
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    pc.c
+ * @brief   Pin Change Driver code.
+ *
+ * @addtogroup PC
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_PC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   PC Driver initialization.
+ * @note    This function is implicitly invoked by @p halInit(), there is
+ *          no need to explicitly initialize the driver.
+ *
+ * @init
+ */
+void pcInit(void) {
+  pc_lld_init();
+}
+
+/**
+ * @brief   Initializes the standard part of a @p PCDriver structure.
+ *
+ * @param[out] pcp     pointer to the @p PCDriver object
+ *
+ * @init
+ */
+void pcObjectInit(PCDriver *pcp) {
+
+  pcp->state  = PC_STOP;
+  pcp->config = NULL;
+}
+
+/**
+ * @brief   Configures and activates the PC peripheral.
+ * @post    After activation all PC channels are in the selected state,
+ *          use @p pcChannelEnable() and  @p pcChannelDisable()
+ *          in order to activate them.
+ *
+ * @param[in] pcp       pointer to the @p PCDriver object
+ * @param[in] config    pointer to the @p PCConfig object
+ *
+ * @api
+ */
+void pcStart(PCDriver *pcp, const PCConfig *config) {
+
+  osalDbgCheck((pcp != NULL) && (config != NULL));
+
+  osalSysLock();
+  osalDbgAssert((pcp->state == PC_STOP) || (pcp->state == PC_ACTIVE),
+                "invalid state");
+  pcp->config = config;
+  pc_lld_start(pcp);
+  pcp->state = PC_ACTIVE;
+  osalSysUnlock();
+}
+
+/**
+ * @brief   Deactivates the PC peripheral.
+ *
+ * @param[in] pcp      pointer to the @p PCDriver object
+ *
+ * @api
+ */
+void pcStop(PCDriver *pcp) {
+
+  osalDbgCheck(pcp != NULL);
+
+  osalSysLock();
+  osalDbgAssert((pcp->state == PC_STOP) || (pcp->state == PC_ACTIVE),
+                "invalid state");
+  pc_lld_stop(pcp);
+  pcp->state = PC_STOP;
+  osalSysUnlock();
+}
+
+/**
+ * @brief   Enables an PC channel.
+ * @pre     The channel must not be in @p PC_CH_MODE_DISABLED mode.
+ *
+ * @param[in] pcp      pointer to the @p PCDriver object
+ * @param[in] channel   channel to be enabled
+ *
+ * @api
+ */
+void pcChannelEnable(PCDriver *pcp, pcchannel_t channel) {
+
+  osalDbgCheck((pcp != NULL) && (channel < (pcchannel_t)PC_MAX_CHANNELS));
+
+  osalSysLock();
+  pcChannelEnableI(pcp, channel);
+  osalSysUnlock();
+}
+
+/**
+ * @brief   Disables an PC channel.
+ * @pre     The channel must not be in @p PC_CH_MODE_DISABLED mode.
+ *
+ * @param[in] pcp      pointer to the @p PCDriver object
+ * @param[in] channel  channel to be disabled
+ *
+ * @api
+ */
+void pcChannelDisable(PCDriver *pcp, pcchannel_t channel) {
+
+  osalDbgCheck((pcp != NULL) && (channel < (pcchannel_t)PC_MAX_CHANNELS));
+
+  osalSysLock();
+  pcChannelDisableI(pcp, channel);
+  osalSysUnlock();
+}
+#endif /* HAL_USE_PC == TRUE */
+
+/** @} */


### PR DESCRIPTION
1) Add support for EXT interrupts on ATMega328P (Arduino UNO)
2) Add support for PC interrupts on ATMega328P (Arduino UNO)
3) Adjust the example accordingly
4) Optimize creation of binary executable by dropping unused portions.