### PR TITLE
Support for ATMega EXT & INT external interrupts.

### DIFF
--- a/os/hal/ports/AVR/ext_lld.c
+++ b/os/hal/ports/AVR/ext_lld.c
@@ -1,0 +1,396 @@
+/*
+    EXT Low Level Driver for ChibiOS
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ext_lld.c
+ * @brief   AVR EXT subsystem low level driver source.
+ *
+ * @addtogroup EXT
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_EXT == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#define EXT_EICRA_LOW_LEVEL    0
+#define EXT_EICRA_BOTH_EDGES   1
+#define EXT_EICRA_FALLING_EDGE 2
+#define EXT_EICRA_RISING_EDGE  3
+
+
+/**
+ * @brief   Declares the isr for the ext channel specified
+ *
+ * @param[in] channel      number of the channel
+ *
+ * @notapi
+ */
+
+#define declare_extint_isr(channel)                            \
+  OSAL_IRQ_HANDLER(INT##channel##_vect)                        \
+  {                                                            \
+    OSAL_IRQ_PROLOGUE();                                       \
+    EXTD1.config->channels[EXT_INT##channel##_CHANNEL].        \
+      cb(&EXTD1, EXT_INT##channel##_CHANNEL);                  \
+    OSAL_IRQ_EPILOGUE();                                       \
+  }
+
+
+/**
+ * @brief   Declares the isr for the pc channel specified
+ *
+ * @param[in] port      number of the port
+ *
+ * @notapi
+ */
+
+#define declare_pcint_isr(index)                                       \
+  OSAL_IRQ_HANDLER(PCINT##index##_vect) {                              \
+    OSAL_IRQ_PROLOGUE();                                               \
+    EXTD1.pc_current_values[index] =                                   \
+      (*(PINS[index])) & (*(PCMSK[index]));                            \
+    EXTD1.config->channels[EXT_PCINT##index##_INDEX]                   \
+      .cb(&EXTD1, EXT_PCINT##index##_INDEX);                           \
+    EXTD1.pc_old_values[index] = EXTD1.pc_current_values[index];       \
+    OSAL_IRQ_EPILOGUE();                                               \
+  }
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   EXT1 driver identifier.
+ */
+#if (AVR_EXT_USE_EXT1 == TRUE) || defined(__DOXYGEN__)
+  EXTDriver EXTD1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Vector with addresses of Ports available.
+ */
+volatile uint8_t * const PINS[EXT_PC_NUM_PORTS] = {
+#if defined(PORTA)
+  (volatile uint8_t *const)&PINA,
+#endif
+#if defined(PORTB)
+  (volatile uint8_t *const)&PINB,
+#endif
+#if defined(PORTC)
+  (volatile uint8_t *const)&PINC,
+#endif
+#if defined(PORTD)
+  (volatile uint8_t *const)&PIND,
+#endif
+#if defined(PORTE)
+  (volatile uint8_t *const)&PINE,
+#endif
+#if defined(PORTF)
+  (volatile uint8_t *const)&PINF,
+#endif
+#if defined(PORTG)
+  (volatile uint8_t *const)&PING,
+#endif
+#if defined(PORTH)
+  (volatile uint8_t *const)&PINH,
+#endif
+#if defined(PORTI)
+  (volatile uint8_t *const)&PINI,
+#endif
+#if defined(PORTJ)
+  (volatile uint8_t *const)&PINJ,
+#endif
+};
+
+/**
+ * @brief   Vector with addresses of Port Masks available.
+ */
+volatile uint8_t * const PCMSK[EXT_PC_NUM_PORTS] = {
+  #if 0 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK0,
+  #endif
+  #if 1 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK1,
+  #endif
+  #if 2 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK2,
+  #endif
+  #if 3 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK3,
+  #endif
+  #if 4 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK4,
+  #endif
+  #if 5 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK5,
+  #endif
+  #if 6 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK6,
+  #endif
+  #if 7 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK7,
+  #endif
+  #if 8 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK8,
+  #endif
+  #if 9 < EXT_PC_NUM_PORTS
+    (volatile uint8_t *const)&PCMSK9,
+  #endif
+};
+
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Configures and activates the Pin Changed  inputs.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ *
+ * @notapi
+ */
+inline void start_pc(EXTDriver *extp) {
+  uint8_t new_PCICR = 0;
+  uint8_t i;
+  for (i = EXT_PC_MIN_PORT; i <= EXT_PC_MAX_PORT; i++)
+    if (extp->config->channels[i].mode) {
+        new_PCICR |= _BV(i - EXT_PC_MIN_PORT);
+        (*(PCMSK[i - EXT_PC_MIN_PORT])) = extp->config->channels[i].mode;
+    }
+  /* Enables/disables the peripheral, as requested. */
+  PCICR = new_PCICR;
+}
+
+
+ /**
+ * @brief   Configures and activates the Pin Changed  inputs.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ *
+ * @notapi
+ */
+inline void start_ext(EXTDriver *extp) {
+  uint8_t new_EICRA = 0;
+  uint8_t new_EIMSK = 0;
+  for (expchannel_t channel = EXT_INT_MIN_CHANNEL;
+       channel <= EXT_INT_MAX_CHANNEL; channel++) {
+    /* Determines the triggering condition for each channell. */
+    switch(extp->config->channels[channel].mode &
+           ~(EXT_CH_MODE_AUTOSTART | EXT_CH_MODE_INTERNAL_PULLUP)) {
+      case EXT_CH_MODE_LOW_LEVEL:
+        new_EICRA |=
+          (EXT_EICRA_LOW_LEVEL << (2 * (channel - EXT_INT_MIN_CHANNEL)));
+        break;
+      case EXT_CH_MODE_BOTH_EDGES:
+        new_EICRA |=
+          (EXT_EICRA_BOTH_EDGES << (2 * (channel - EXT_INT_MIN_CHANNEL)));
+        break;
+      case EXT_CH_MODE_RISING_EDGE:
+        new_EICRA |=
+          (EXT_EICRA_RISING_EDGE << (2 * (channel - EXT_INT_MIN_CHANNEL)));
+        break;
+      case EXT_CH_MODE_FALLING_EDGE:
+        new_EICRA |=
+          (EXT_EICRA_FALLING_EDGE << (2 * (channel - EXT_INT_MIN_CHANNEL)));
+        break;
+      default: osalDbgAssert(FALSE, "unsupported mode");
+    }
+    if (extp->config->channels[channel].mode & EXT_CH_MODE_AUTOSTART)
+      new_EIMSK |= (1 << (channel - EXT_INT_MIN_CHANNEL));
+    /* Determines which channel must be started right away. */
+    if (extp->config->channels[channel].mode & EXT_CH_MODE_AUTOSTART)
+      new_EIMSK |= (1 << (channel - EXT_INT_MIN_CHANNEL));
+  }
+  /* Configures the peripheral. */
+  EICRA = new_EICRA;
+  /* Enables/disables the peripheral, as requested. */
+  EIMSK = new_EIMSK;
+}
+
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+  /*
+   * Interrupt handlers for PC-type interrupts.
+   */
+#if AVR_EXT_USE_EXT1 || defined(__DOXYGEN__)
+  #define EXT_PCINT_MIN_INDEX    EXT_PC_MIN_PORT
+  #if 0 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT0_INDEX     EXT_PCINT_MIN_INDEX
+    declare_pcint_isr(0);
+  #endif
+  #if 1 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT1_INDEX    (EXT_PCINT0_INDEX  + 1)
+    declare_pcint_isr(1);
+  #endif
+  #if 2 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT2_INDEX    (EXT_PCINT1_INDEX  + 1)
+    declare_pcint_isr(2);
+  #endif
+  #if 3 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT3_INDEX    (EXT_PCINT2_INDEX  + 1)
+    declare_pcint_isr(3);
+  #endif
+  #if 4 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT4_INDEX    (EXT_PCINT3_INDEX  + 1)
+    declare_pcint_isr(4);
+  #endif
+  #if 5 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT5_INDEX    (EXT_PCINT4_INDEX  + 1)
+    declare_pcint_isr(5);
+  #endif
+  #if 6 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT6_INDEX    (EXT_PCINT5_INDEX  + 1)
+    declare_pcint_isr(6);
+  #endif
+  #if 7 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT7_INDEX    (EXT_PCINT6_INDEX  + 1)
+    declare_pcint_isr(7);
+  #endif
+  #if 8 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT8_INDEX    (EXT_PCINT7_INDEX  + 1)
+    declare_pcint_isr(8);
+  #endif
+  #if 9 < EXT_PC_NUM_PORTS
+    #define  EXT_PCINT9_INDEX    (EXT_PCINT8_INDEX  + 1)
+    declare_pcint_isr(9);
+  #endif
+
+  /*
+   * Interrupt handlers for EXT-type interrupts.
+   */
+  #if 0 < EXT_INT_NUM_CHANNELS
+    declare_extint_isr(0);
+  #endif
+  #if 1 < EXT_INT_NUM_CHANNELS
+    declare_extint_isr(1);
+  #endif
+  #if 2 < EXT_INT_NUM_CHANNELS
+    declare_extint_isr(2);
+  #endif
+  #if 3 < EXT_INT_NUM_CHANNELS
+    declare_extint_isr(3);
+  #endif
+#endif
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level EXT driver initialization.
+ *
+ * @notapi
+ */
+void ext_lld_init(void) {
+#if AVR_EXT_USE_EXT1 == TRUE
+  /* Driver initialization.*/
+  extObjectInit(&EXTD1);
+  for (int i = 0; i < EXT_PC_NUM_PORTS; i++)
+    EXTD1.pc_old_values[i] = 0;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the EXT peripheral.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ *
+ * @notapi
+ */
+void ext_lld_start(EXTDriver *extp) {
+#if AVR_EXT_USE_EXT1 == TRUE
+  start_ext(extp);
+  start_pc(extp);
+#endif
+}
+
+/**
+ * @brief   Deactivates the EXT peripheral.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ *
+ * @notapi
+ */
+void ext_lld_stop(EXTDriver *extp) {
+
+  if (extp->state == EXT_ACTIVE) {
+    /* Disables the peripheral.*/
+#if AVR_EXT_USE_EXT1 == TRUE
+    if (&EXTD1 == extp) {
+      EIMSK = 0;
+      PCICR = 0;
+    }
+#endif
+  }
+}
+
+/**
+ * @brief   Enables an EXT channel.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ * @param[in] channel   channel to be enabled
+ *
+ * @notapi
+ */
+void ext_lld_channel_enable(EXTDriver *extp, expchannel_t channel) {
+  if (EXT_PC_MIN_CHANNEL <= channel && channel <= EXT_PC_MAX_CHANNEL) {
+    uint8_t port = channel / 8;
+    (*(uint8_t*)&(extp->config->channels[port].mode)) |= _BV(channel % 8);
+    (*(PCMSK[port])) = extp->config->channels[port].mode;
+    PCICR |= _BV(port);
+  } else if (EXT_INT_MIN_CHANNEL <= channel &&
+             EXT_INT_MAX_CHANNEL >= channel) {
+    EIMSK |= (1 << (channel - EXT_INT_MIN_CHANNEL));
+  }
+}
+
+/**
+ * @brief   Disables an EXT channel.
+ *
+ * @param[in] extp      pointer to the @p EXTDriver object
+ * @param[in] channel   channel to be disabled
+ *
+ * @notapi
+ */
+void ext_lld_channel_disable(EXTDriver *extp, expchannel_t channel) {
+  if (EXT_PC_MIN_CHANNEL <= channel && channel <= EXT_PC_MAX_CHANNEL) {
+    uint8_t port = channel / 8;
+    (*(uint8_t*)&(extp->config->channels[port].mode)) &= ~_BV(channel % 8);
+    (*(PCMSK[port])) = extp->config->channels[port].mode;
+    if (extp->config->channels[port].mode == 0)
+      PCICR &= ~_BV(port);
+  } else if (EXT_INT_MIN_CHANNEL <= channel &&
+             EXT_INT_MAX_CHANNEL >= channel) {
+    EIMSK &= ~(1 << (channel - EXT_INT_MIN_CHANNEL));
+  }
+}
+#endif /* HAL_USE_EXT == TRUE */
+
+/** @} */

--- a/os/hal/ports/AVR/ext_lld.h
+++ b/os/hal/ports/AVR/ext_lld.h
@@ -1,0 +1,306 @@
+/*
+    EXT Low Level Driver for ChibiOS
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ext_lld.h
+ * @brief   AVR EXT subsystem low level driver header.
+ *
+ * @addtogroup EXT
+ * @{
+ */
+
+#ifndef _EXT_LLD_H_
+#define _EXT_LLD_H_
+
+#if (HAL_USE_EXT == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Indexes of EXT channels.
+ */
+#define EXT_INT_MIN_CHANNEL 0
+#if defined(INT0_vect)
+  #define EXT_INT0_PRESENT 1
+  #define EXT_INT0_CHANNEL   EXT_INT_MIN_CHANNEL
+#else
+  #define EXT_INT0_PRESENT 0
+  #define EXT_INT0_CHANNEL   (EXT_INT_MIN_CHANNEL - 1)
+#endif
+
+#if defined(INT1_vect)
+  #define EXT_INT1_PRESENT 1
+  #define EXT_INT1_CHANNEL   (EXT_INT0_CHANNEL + 1)
+#else
+  #define EXT_INT1_PRESENT 0
+  #define EXT_INT1_CHANNEL   EXT_INT0_CHANNEL
+#endif
+
+#if defined(INT2_vect)
+  #define EXT_INT2_PRESENT 1
+  #define EXT_INT2_CHANNEL   (EXT_INT1_CHANNEL + 1)
+#else
+  #define EXT_INT2_PRESENT 0
+  #define EXT_INT2_CHANNEL   EXT_INT1_CHANNEL
+#endif
+
+#if defined(INT3_vect)
+  #define EXT_INT3_PRESENT 1
+  #define EXT_INT3_CHANNEL   (EXT_INT2_CHANNEL + 1)
+#else
+  #define EXT_INT3_PRESENT 0
+  #define EXT_INT3_CHANNEL   EXT_INT2_CHANNEL
+#endif
+
+#define EXT_INT_NUM_CHANNELS \
+    (EXT_INT0_PRESENT + EXT_INT1_PRESENT + \
+     EXT_INT2_PRESENT + EXT_INT3_PRESENT)
+
+#define EXT_INT_MAX_CHANNEL \
+  (EXT_INT_MIN_CHANNEL + EXT_INT_NUM_CHANNELS - 1)
+
+/**
+ * @brief   Indexes of EXT channels.
+ */
+#define EXT_PC_MIN_PORT     EXT_INT_NUM_CHANNELS
+#if defined(PORTA)
+  #define PORTA_PRESENT 1
+  #define PORTA_INDEX   EXT_PC_MIN_PORT
+#else
+  #define PORTA_PRESENT 0
+  #define PORTA_INDEX   (EXT_PC_MIN_PORT - 1)
+#endif
+
+#if defined(PORTB)
+  #define PORTB_PRESENT 1
+  #define PORTB_INDEX   (PORTA_INDEX + 1)
+#else
+  #define PORTB_PRESENT 0
+  #define PORTB_INDEX   PORTA_INDEX
+#endif
+
+#if defined(PORTC)
+  #define PORTC_PRESENT 1
+  #define PORTC_INDEX   (PORTB_INDEX + 1)
+#else
+  #define PORTC_PRESENT 0
+  #define PORTC_INDEX   PORTB_INDEX
+#endif
+
+#if defined(PORTD)
+  #define PORTD_PRESENT 1
+  #define PORTD_INDEX   (PORTC_INDEX + 1)
+#else
+  #define PORTD_PRESENT 0
+  #define PORTD_INDEX   PORTC_INDEX
+#endif
+
+#if defined(PORTE)
+  #define PORTE_PRESENT 1
+  #define PORTE_INDEX   (PORTD_INDEX + 1)
+#else
+  #define PORTE_PRESENT 0
+  #define PORTE_INDEX   PORTD_INDEX
+#endif
+
+#if defined(PORTF)
+  #define PORTF_PRESENT 1
+  #define PORTF_INDEX   (PORTE_INDEX + 1)
+#else
+  #define PORTF_PRESENT 0
+  #define PORTF_INDEX   PORTE_INDEX
+#endif
+
+#if defined(PORTG)
+  #define PORTG_PRESENT 1
+  #define PORTG_INDEX   (PORTF_INDEX + 1)
+#else
+  #define PORTG_PRESENT 0
+  #define PORTG_INDEX   PORTF_INDEX
+#endif
+
+#if defined(PORTH)
+  #define PORTH_PRESENT 1
+  #define PORTH_INDEX   (PORTG_INDEX + 1)
+#else
+  #define PORTH_PRESENT 0
+  #define PORTH_INDEX   PORTG_INDEX
+#endif
+
+#if defined(PORTI)
+  #define PORTI_PRESENT 1
+  #define PORTI_INDEX   (PORTH_INDEX + 1)
+#else
+  #define PORTI_PRESENT 0
+  #define PORTI_INDEX   PORTH_INDEX
+#endif
+
+#if defined(PORTJ)
+  #define PORTJ_PRESENT 1
+  #define PORTJ_INDEX   (PORTI_INDEX + 1)
+#else
+  #define PORTJ_PRESENT 0
+  #define PORTJ_INDEX   PORTI_INDEX
+#endif
+
+#if defined(PORTK)
+  #define PORTK_PRESENT 1
+  #define PORTK_INDEX   (PORTJ_INDEX + 1)
+#else
+  #define PORTK_PRESENT 0
+  #define PORTK_INDEX   PORTJ_INDEX
+#endif
+
+/**
+ * @brief   Available number of PC ports.
+ */
+
+#define EXT_PC_NUM_PORTS  \
+    (PORTA_PRESENT + PORTB_PRESENT + PORTC_PRESENT + PORTD_PRESENT +\
+     PORTE_PRESENT + PORTF_PRESENT + PORTG_PRESENT + PORTH_PRESENT +\
+     PORTI_PRESENT + PORTJ_PRESENT + PORTK_PRESENT)
+
+#define EXT_PC_MAX_PORT (EXT_PC_MIN_PORT + EXT_PC_NUM_PORTS - 1)
+
+#define EXT_TOTAL_CHANNELS (EXT_INT_NUM_CHANNELS + EXT_PC_NUM_PORTS)
+#define EXT_MAX_CHANNELS EXT_TOTAL_CHANNELS
+#define EXT_PC_MIN_CHANNEL EXT_INT_NUM_CHANNELS
+#define EXT_PC_MAX_CHANNEL (EXT_PC_MIN_CHANNEL + EXT_PC_NUM_PORTS * 8 - 1)
+/**
+ * @brief  Level-driven irq generation.
+ */
+#define EXT_CH_MODE_LEVELS_MASK       8U  /**< @brief Mask of levels field. */
+#define EXT_CH_MODE_LOW_LEVEL         8U  /**< @brief Trigger on Low level. */
+#define EXT_CH_MODE_INTERNAL_PULLUP  16U  /**< @brief Use internal pullup.  */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    AVR configuration options
+ * @{
+ */
+/**
+ * @brief   EXT driver enable switch.
+ * @details If set to @p TRUE the support for EXT1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(AVR_EXT_USE_EXT1) || defined(__DOXYGEN__)
+#define AVR_EXT_USE_EXT1               FALSE
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   EXT channel identifier.
+ */
+typedef uint8_t expchannel_t;
+
+/**
+ * @brief   Type of an EXT generic notification callback.
+ *
+ * @param[in] extp      pointer to the @p EXPDriver object triggering the
+ *                      callback
+ * @param[in] channel   channel being triggered.
+ */
+typedef void (*extcallback_t)(EXTDriver *extp, expchannel_t channel);
+
+/**
+ * @brief   Channel configuration structure.
+ */
+typedef struct {
+  /**
+   * @brief Channel mode from HAL.
+   */
+  uint8_t              mode;
+  /**
+   * @brief Channel callback.
+   */
+  extcallback_t         cb;
+} EXTChannelConfig;
+
+/**
+ * @brief   Driver configuration structure.
+ * @note    It could be empty on some architectures.
+ */
+typedef struct {
+  /**
+   * @brief Channel configurations.
+   */
+  EXTChannelConfig      channels[EXT_TOTAL_CHANNELS];
+  /* End of the mandatory fields.*/
+} EXTConfig;
+
+/**
+ * @brief   Structure representing an EXT driver.
+ */
+struct EXTDriver {
+  /**
+   * @brief Driver state.
+   */
+  extstate_t                state;
+  /**
+   * @brief Current configuration data.
+   */
+  const EXTConfig           *config;
+  /* End of the mandatory fields.*/
+  uint8_t pc_current_values[EXT_PC_NUM_PORTS];
+  uint8_t pc_old_values[EXT_PC_NUM_PORTS];
+};
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+#define ext_port_to_channel(port, bit) \
+  ((PORT##port##_INDEX - EXT_PC_MIN_PORT) * 8 + bit)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (AVR_EXT_USE_EXT1 == TRUE) && !defined(__DOXYGEN__)
+extern EXTDriver EXTD1;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void ext_lld_init(void);
+  void ext_lld_start(EXTDriver *extp);
+  void ext_lld_stop(EXTDriver *extp);
+  void ext_lld_channel_enable(EXTDriver *extp, expchannel_t channel);
+  void ext_lld_channel_disable(EXTDriver *extp, expchannel_t channel);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_EXT == TRUE */
+
+#endif /* _EXT_LLD_H_ */
+
+/** @} */

--- a/os/hal/ports/AVR/platform.mk
+++ b/os/hal/ports/AVR/platform.mk
@@ -1,6 +1,7 @@
 # List of all the AVR platform files.
 PLATFORMSRC = ${CHIBIOS}/os/hal/ports/AVR/hal_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/pal_lld.c \
+              ${CHIBIOS}/os/hal/ports/AVR/ext_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/serial_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/adc_lld.c \
               ${CHIBIOS}/os/hal/ports/AVR/i2c_lld.c \

--- a/testhal/AVR/EXT/Makefile
+++ b/testhal/AVR/EXT/Makefile
@@ -1,0 +1,562 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+# WinAVR Makefile Template written by Eric B. Weddington, Jörg Wunsch, et al.
+#
+# Released to the Public Domain
+#
+# Additional material for this makefile was written by:
+# Peter Fleury
+# Tim Henigan
+# Colin O'Flynn
+# Reiner Patommel
+# Markus Pfaff
+# Sander Pool
+# Frederik Rouleau
+# Carlos Lamas
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make debug = Start either simulavr or avarice as specified for debugging,
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# MCU name
+MCU = atmega328p
+
+# Processor frequency.
+F_CPU = 16000000
+
+# Output format. (can be srec, ihex, binary)
+FORMAT = ihex
+
+# Target file name (without extension).
+TARGET = ch
+
+# Object files directory
+#     To put object files in current directory, use a dot (.), do NOT make
+#     this an empty or blank macro!
+OBJDIR = .
+
+# Imported source files
+CHIBIOS = ../../..
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/boards/ARDUINO_UNO/board.mk
+include $(CHIBIOS)/os/hal/ports/AVR/platform.mk
+include $(CHIBIOS)/os/hal/osal/rt/osal.mk
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/rt/ports/AVR/compilers/GCC/mk/port.mk
+#include $(CHIBIOS)/test/rt/test.mk
+
+# List C source files here. (C dependencies are automatically generated.)
+SRC = $(KERNSRC) \
+      $(PORTSRC) \
+      $(OSALSRC) \
+      $(HALSRC) \
+      $(PLATFORMSRC) \
+      $(BOARDSRC) \
+      $(CHIBIOS)/os/various/evtimer.c \
+      main.c
+
+# List C++ source files here. (C dependencies are automatically generated.)
+CPPSRC =
+
+# List Assembler source files here.
+#     Make them always end in a capital .S.  Files ending in a lowercase .s
+#     will not be considered source files but generated files (assembler
+#     output from the compiler), and will be deleted upon "make clean"!
+#     Even though the DOS/Win* filesystem matches both .s and .S the same,
+#     it will preserve the spelling of the filenames, and gcc itself does
+#     care about how the name is spelled on its command-line.
+ASRC =
+
+# Optimization level, can be [0, 1, 2, 3, s].
+#     0 = turn off optimization. s = optimize for size.
+#     (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
+OPT = 2
+
+# Debugging format.
+#     Native formats for AVR-GCC's -g are dwarf-2 [default] or stabs.
+#     AVR Studio 4.10 requires dwarf-2.
+#     AVR [Extended] COFF format requires stabs, plus an avr-objcopy run.
+DEBUG = dwarf-2
+
+# List any extra directories to look for include files here.
+#     Each directory must be seperated by a space.
+#     Use forward slashes for directory separators.
+#     For a directory that has spaces, enclose it in quotes.
+EXTRAINCDIRS = $(PORTINC) $(KERNINC) $(TESTINC) \
+               $(HALINC) $(OSALINC) $(PLATFORMINC) \
+               $(BOARDINC) $(CHIBIOS)/os/various
+
+# Compiler flag to set the C Standard level.
+#     c89   = "ANSI" C
+#     gnu89 = c89 plus GCC extensions
+#     c99   = ISO C99 standard (not yet fully implemented)
+#     gnu99 = c99 plus GCC extensions
+CSTANDARD = -std=gnu11
+
+# Place -D or -U options here for C sources
+CDEFS = -DF_CPU=$(F_CPU)UL
+
+# Place -D or -U options here for ASM sources
+ADEFS = -DF_CPU=$(F_CPU)
+
+# Place -D or -U options here for C++ sources
+CPPDEFS = -DF_CPU=$(F_CPU)UL
+#CPPDEFS += -D__STDC_LIMIT_MACROS
+#CPPDEFS += -D__STDC_CONSTANT_MACROS
+
+#---------------- Compiler Options C ----------------
+#  -g*:          generate debugging information
+#  -O*:          optimization level
+#  -f...:        tuning, see GCC manual and avr-libc documentation
+#  -Wall...:     warning level
+#  -Wa,...:      tell GCC to pass this to the assembler.
+#    -adhlns...: create assembler listing
+CFLAGS = -g$(DEBUG)
+CFLAGS += $(CDEFS)
+CFLAGS += -O$(OPT)
+CFLAGS += -funsigned-char
+CFLAGS += -fdata-sections
+CFLAGS += -ffunction-sections
+CFLAGS += -funsigned-bitfields
+CFLAGS += -fpack-struct
+CFLAGS += -fshort-enums
+#CFLAGS += -fno-strict-aliasing
+CFLAGS += -Wall
+CFLAGS += -Wstrict-prototypes
+#CFLAGS += -mshort-calls
+#CFLAGS += -fno-unit-at-a-time
+CFLAGS += -Wundef
+CFLAGS += -Wunreachable-code
+CFLAGS += -Wsign-compare
+CFLAGS += -Wa,-adhlns=$(<:%.c=$(OBJDIR)/%.lst)
+CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
+CFLAGS += $(CSTANDARD)
+#CFLAGS += -mrelax
+
+#---------------- Compiler Options C++ ----------------
+#  -g*:          generate debugging information
+#  -O*:          optimization level
+#  -f...:        tuning, see GCC manual and avr-libc documentation
+#  -Wall...:     warning level
+#  -Wa,...:      tell GCC to pass this to the assembler.
+#    -adhlns...: create assembler listing
+CPPFLAGS = -g$(DEBUG)
+CPPFLAGS += $(CPPDEFS)
+CPPFLAGS += -O$(OPT)
+CPPFLAGS += -funsigned-char
+CPPFLAGS += -fdata-sections
+CPPFLAGS += -ffunction-sections
+CPPFLAGS += -funsigned-bitfields
+CPPFLAGS += -fpack-struct
+CPPFLAGS += -fshort-enums
+CPPFLAGS += -fno-exceptions
+CPPFLAGS += -Wall
+CFLAGS += -Wundef
+#CPPFLAGS += -mshort-calls
+#CPPFLAGS += -fno-unit-at-a-time
+#CPPFLAGS += -Wstrict-prototypes
+CPPFLAGS += -Wunreachable-code
+CPPFLAGS += -Wsign-compare
+CPPFLAGS += -Wa,-adhlns=$(<:%.cpp=$(OBJDIR)/%.lst)
+CPPFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
+#CPPFLAGS += $(CSTANDARD)
+
+#---------------- Assembler Options ----------------
+#  -Wa,...:   tell GCC to pass this to the assembler.
+#  -adhlns:   create listing
+#  -gstabs:   have the assembler create line number information; note that
+#             for use in COFF files, additional information about filenames
+#             and function names needs to be present in the assembler source
+#             files -- see avr-libc docs [FIXME: not yet described there]
+#  -listing-cont-lines: Sets the maximum number of continuation lines of hex
+#       dump that will be displayed for a given single line of source input.
+ASFLAGS = $(ADEFS) -Wa,-adhlns=$(<:%.S=$(OBJDIR)/%.lst),-gstabs,--listing-cont-lines=100
+
+#---------------- Library Options ----------------
+# Minimalistic printf version
+PRINTF_LIB_MIN = -Wl,-u,vfprintf -lprintf_min
+
+# Floating point printf version (requires MATH_LIB = -lm below)
+PRINTF_LIB_FLOAT = -Wl,-u,vfprintf -lprintf_flt
+
+# If this is left blank, then it will use the Standard printf version.
+PRINTF_LIB = $(PRINTF_LIB_MIN)
+#PRINTF_LIB = $(PRINTF_LIB_MIN)
+#PRINTF_LIB = $(PRINTF_LIB_FLOAT)
+
+# Minimalistic scanf version
+SCANF_LIB_MIN = -Wl,-u,vfscanf -lscanf_min
+
+# Floating point + %[ scanf version (requires MATH_LIB = -lm below)
+SCANF_LIB_FLOAT = -Wl,-u,vfscanf -lscanf_flt
+
+# If this is left blank, then it will use the Standard scanf version.
+SCANF_LIB = $(SCANF_LIB_MIN)
+#SCANF_LIB = $(SCANF_LIB_MIN)
+#SCANF_LIB = $(SCANF_LIB_FLOAT)
+
+MATH_LIB = -lm
+
+# List any extra directories to look for libraries here.
+#     Each directory must be seperated by a space.
+#     Use forward slashes for directory separators.
+#     For a directory that has spaces, enclose it in quotes.
+EXTRALIBDIRS =
+
+#---------------- External Memory Options ----------------
+
+# 64 KB of external RAM, starting after internal RAM (ATmega128!),
+# used for variables (.data/.bss) and heap (malloc()).
+#EXTMEMOPTS = -Wl,-Tdata=0x801100,--defsym=__heap_end=0x80ffff
+
+# 64 KB of external RAM, starting after internal RAM (ATmega128!),
+# only used for heap (malloc()).
+#EXTMEMOPTS = -Wl,--section-start,.data=0x801100,--defsym=__heap_end=0x80ffff
+
+EXTMEMOPTS =
+
+#---------------- Linker Options ----------------
+#  -Wl,...:     tell GCC to pass this to linker.
+#    -Map:      create map file
+#    --cref:    add cross reference to  map file
+LDFLAGS = -Wl,-Map=$(TARGET).map,--cref,--gc-sections
+LDFLAGS += $(EXTMEMOPTS)
+LDFLAGS += $(patsubst %,-L%,$(EXTRALIBDIRS))
+LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)
+#LDFLAGS += -T linker_script.x
+
+#---------------- Programming Options (avrdude) ----------------
+
+# Programming hardware: alf avr910 avrisp bascom bsd
+# dt006 pavr picoweb pony-stk200 sp12 stk200 stk500
+#
+# Type: avrdude -c ?
+# to get a full listing.
+#
+AVRDUDE_PROGRAMMER = avrisp2 
+
+# com1 = serial port. Use lpt1 to connect to parallel port.
+AVRDUDE_PORT = /dev/tty.usbmodem00034091
+
+AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
+#AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
+
+# Uncomment the following if you want avrdude's erase cycle counter.
+# Note that this counter needs to be initialized first using -Yn,
+# see avrdude manual.
+#AVRDUDE_ERASE_COUNTER = -y
+
+# Uncomment the following if you do /not/ wish a verification to be
+# performed after programming the device.
+#AVRDUDE_NO_VERIFY = -V
+
+# Increase verbosity level.  Please use this when submitting bug
+# reports about avrdude. See <http://savannah.nongnu.org/projects/avrdude>
+# to submit bug reports.
+#AVRDUDE_VERBOSE = -v -v
+
+AVRDUDE_FLAGS = -p $(MCU)
+AVRDUDE_FLAGS += -P $(AVRDUDE_PORT)
+AVRDUDE_FLAGS += -b 57600
+AVRDUDE_FLAGS += -c $(AVRDUDE_PROGRAMMER)
+AVRDUDE_FLAGS += $(AVRDUDE_NO_VERIFY)
+AVRDUDE_FLAGS += $(AVRDUDE_VERBOSE)
+AVRDUDE_FLAGS += $(AVRDUDE_ERASE_COUNTER)
+
+#---------------- Debugging Options ----------------
+
+# For simulavr only - target MCU frequency.
+DEBUG_MFREQ = $(F_CPU)
+
+# Set the DEBUG_UI to either gdb or insight.
+# DEBUG_UI = gdb
+DEBUG_UI = insight
+
+# Set the debugging back-end to either avarice, simulavr.
+DEBUG_BACKEND = avarice
+#DEBUG_BACKEND = simulavr
+
+# GDB Init Filename.
+GDBINIT_FILE = __avr_gdbinit
+
+# When using avarice settings for the JTAG
+JTAG_DEV = /dev/com1
+
+# Debugging port used to communicate between GDB / avarice / simulavr.
+DEBUG_PORT = 4242
+
+# Debugging host used to communicate between GDB / avarice / simulavr, normally
+#     just set to localhost unless doing some sort of crazy debugging when
+#     avarice is running on a different computer.
+DEBUG_HOST = localhost
+
+#============================================================================
+
+# Define programs and commands.
+SHELL = sh
+CC = avr-gcc
+OBJCOPY = avr-objcopy
+OBJDUMP = avr-objdump
+SIZE = avr-size
+AR = avr-ar rcs
+NM = avr-nm
+AVRDUDE = avrdude
+REMOVE = rm -f
+REMOVEDIR = rm -rf
+COPY = cp
+WINSHELL = cmd
+
+# Define Messages
+# English
+MSG_ERRORS_NONE = Errors: none
+MSG_BEGIN = -------- begin --------
+MSG_END = --------  end  --------
+MSG_SIZE_BEFORE = Size before:
+MSG_SIZE_AFTER = Size after:
+MSG_COFF = Converting to AVR COFF:
+MSG_EXTENDED_COFF = Converting to AVR Extended COFF:
+MSG_FLASH = Creating load file for Flash:
+MSG_EEPROM = Creating load file for EEPROM:
+MSG_EXTENDED_LISTING = Creating Extended Listing:
+MSG_SYMBOL_TABLE = Creating Symbol Table:
+MSG_LINKING = Linking:
+MSG_COMPILING = Compiling C:
+MSG_COMPILING_CPP = Compiling C++:
+MSG_ASSEMBLING = Assembling:
+MSG_CLEANING = Cleaning project:
+MSG_CREATING_LIBRARY = Creating library:
+
+# Define all object files.
+OBJ = $(SRC:%.c=$(OBJDIR)/%.o) $(CPPSRC:%.cpp=$(OBJDIR)/%.o) $(ASRC:%.S=$(OBJDIR)/%.o)
+
+# Define all listing files.
+LST = $(SRC:%.c=$(OBJDIR)/%.lst) $(CPPSRC:%.cpp=$(OBJDIR)/%.lst) $(ASRC:%.S=$(OBJDIR)/%.lst)
+
+# Compiler flags to generate dependency files.
+GENDEPFLAGS = -MMD -MP -MF .dep/$(@F).d
+
+# Combine all necessary flags and optional flags.
+# Add target processor to flags.
+ALL_CFLAGS = -mmcu=$(MCU) -I. $(CFLAGS) $(GENDEPFLAGS)
+ALL_CPPFLAGS = -mmcu=$(MCU) -I. -x c++ $(CPPFLAGS) $(GENDEPFLAGS)
+ALL_ASFLAGS = -mmcu=$(MCU) -I. -x assembler-with-cpp $(ASFLAGS)
+
+# Default target.
+all: begin gccversion sizebefore build sizeafter end
+
+# Change the build target to build a HEX file or a library.
+build: elf hex bin eep lss sym
+#build: lib
+
+elf: $(TARGET).elf
+hex: $(TARGET).hex
+bin: $(TARGET).bin
+eep: $(TARGET).eep
+lss: $(TARGET).lss
+sym: $(TARGET).sym
+LIBNAME=lib$(TARGET).a
+lib: $(LIBNAME)
+
+# Eye candy.
+# AVR Studio 3.x does not check make's exit code but relies on
+# the following magic strings to be generated by the compile job.
+begin:
+	@echo
+	@echo $(MSG_BEGIN)
+
+end:
+	@echo $(MSG_END)
+	@echo
+
+# Display size of file.
+HEXSIZE = $(SIZE) --target=$(FORMAT) $(TARGET).hex
+ELFSIZE = $(SIZE) --mcu=$(MCU) --format=avr $(TARGET).elf
+
+sizebefore:
+	@if test -f $(TARGET).elf; then echo; echo $(MSG_SIZE_BEFORE); $(ELFSIZE); \
+	2>/dev/null; echo; fi
+
+sizeafter:
+	@if test -f $(TARGET).elf; then echo; echo $(MSG_SIZE_AFTER); $(ELFSIZE); \
+	2>/dev/null; echo; fi
+
+# Display compiler version information.
+gccversion :
+	@$(CC) --version
+
+# Program the device.
+program: $(TARGET).hex $(TARGET).eep
+	$(AVRDUDE) $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_FLASH) $(AVRDUDE_WRITE_EEPROM)
+
+# Generate avr-gdb config/init file which does the following:
+#     define the reset signal, load the target file, connect to target, and set
+#     a breakpoint at main().
+gdb-config:
+	@$(REMOVE) $(GDBINIT_FILE)
+	@echo define reset >> $(GDBINIT_FILE)
+	@echo SIGNAL SIGHUP >> $(GDBINIT_FILE)
+	@echo end >> $(GDBINIT_FILE)
+	@echo file $(TARGET).elf >> $(GDBINIT_FILE)
+	@echo target remote $(DEBUG_HOST):$(DEBUG_PORT)  >> $(GDBINIT_FILE)
+ifeq ($(DEBUG_BACKEND),simulavr)
+	@echo load  >> $(GDBINIT_FILE)
+endif
+	@echo break main >> $(GDBINIT_FILE)
+
+debug: gdb-config $(TARGET).elf
+ifeq ($(DEBUG_BACKEND), avarice)
+	@echo Starting AVaRICE - Press enter when "waiting to connect" message displays.
+	@$(WINSHELL) /c start avarice --jtag $(JTAG_DEV) --erase --program --file \
+	$(TARGET).elf $(DEBUG_HOST):$(DEBUG_PORT)
+	@$(WINSHELL) /c pause
+
+else
+	@$(WINSHELL) /c start simulavr --gdbserver --device $(MCU) --clock-freq \
+	$(DEBUG_MFREQ) --port $(DEBUG_PORT)
+endif
+	@$(WINSHELL) /c start avr-$(DEBUG_UI) --command=$(GDBINIT_FILE)
+
+# Convert ELF to COFF for use in debugging / simulating in AVR Studio or VMLAB.
+COFFCONVERT = $(OBJCOPY) --debugging
+COFFCONVERT += --change-section-address .data-0x800000
+COFFCONVERT += --change-section-address .bss-0x800000
+COFFCONVERT += --change-section-address .noinit-0x800000
+COFFCONVERT += --change-section-address .eeprom-0x810000
+
+coff: $(TARGET).elf
+	@echo
+	@echo $(MSG_COFF) $(TARGET).cof
+	$(COFFCONVERT) -O coff-avr $< $(TARGET).cof
+
+extcoff: $(TARGET).elf
+	@echo
+	@echo $(MSG_EXTENDED_COFF) $(TARGET).cof
+	$(COFFCONVERT) -O coff-ext-avr $< $(TARGET).cof
+
+# Create final output files (.hex, .eep) from ELF output file.
+%.hex: %.elf
+	@echo
+	@echo $(MSG_FLASH) $@
+	$(OBJCOPY) -O $(FORMAT) -R .eeprom $< $@
+
+%.bin: %.elf
+	@echo
+	@echo $(MSG_FLASH) $@
+	$(OBJCOPY) -O binary -R .eeprom $< $@
+
+%.eep: %.elf
+	@echo
+	@echo $(MSG_EEPROM) $@
+	-$(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" \
+	--change-section-lma .eeprom=0 --no-change-warnings -O $(FORMAT) $< $@ || exit 0
+
+# Create extended listing file from ELF output file.
+%.lss: %.elf
+	@echo
+	@echo $(MSG_EXTENDED_LISTING) $@
+	$(OBJDUMP) -h -S $< > $@
+
+# Create a symbol table from ELF output file.
+%.sym: %.elf
+	@echo
+	@echo $(MSG_SYMBOL_TABLE) $@
+	$(NM) -n $< > $@
+
+# Create library from object files.
+.SECONDARY : $(TARGET).a
+.PRECIOUS : $(OBJ)
+%.a: $(OBJ)
+	@echo
+	@echo $(MSG_CREATING_LIBRARY) $@
+	$(AR) $@ $(OBJ)
+
+# Link: create ELF output file from object files.
+.SECONDARY : $(TARGET).elf
+.PRECIOUS : $(OBJ)
+%.elf: $(OBJ)
+	@echo
+	@echo $(MSG_LINKING) $@
+	$(CC) $(ALL_CFLAGS) $^ --output $@ $(LDFLAGS)
+
+# Compile: create object files from C source files.
+$(OBJDIR)/%.o : %.c
+	@echo
+	@echo $(MSG_COMPILING) $<
+	$(CC) -c $(ALL_CFLAGS) $< -o $@
+
+# Compile: create object files from C++ source files.
+$(OBJDIR)/%.o : %.cpp
+	@echo
+	@echo $(MSG_COMPILING_CPP) $<
+	$(CC) -c $(ALL_CPPFLAGS) $< -o $@
+
+# Compile: create assembler files from C source files.
+%.s : %.c
+	$(CC) -S $(ALL_CFLAGS) $< -o $@
+
+# Compile: create assembler files from C++ source files.
+%.s : %.cpp
+	$(CC) -S $(ALL_CPPFLAGS) $< -o $@
+
+# Assemble: create object files from assembler source files.
+$(OBJDIR)/%.o : %.S
+	@echo
+	@echo $(MSG_ASSEMBLING) $<
+	$(CC) -c $(ALL_ASFLAGS) $< -o $@
+
+# Create preprocessed source for use in sending a bug report.
+%.i : %.c
+	$(CC) -E -mmcu=$(MCU) -I. $(CFLAGS) $< -o $@
+
+# Target: clean project.
+clean: begin clean_list end
+
+clean_list :
+	@echo
+	@echo $(MSG_CLEANING)
+	$(REMOVE) $(TARGET).hex
+	$(REMOVE) $(TARGET).bin
+	$(REMOVE) $(TARGET).eep
+	$(REMOVE) $(TARGET).cof
+	$(REMOVE) $(TARGET).elf
+	$(REMOVE) $(TARGET).map
+	$(REMOVE) $(TARGET).sym
+	$(REMOVE) $(TARGET).lss
+	$(REMOVE) $(SRC:%.c=$(OBJDIR)/%.o)
+	$(REMOVE) $(SRC:%.c=$(OBJDIR)/%.lst)
+	$(REMOVE) $(SRC:.c=.s)
+	$(REMOVE) $(SRC:.c=.d)
+	$(REMOVE) $(SRC:.c=.i)
+	$(REMOVEDIR) .dep
+
+# Create object files directory
+$(shell mkdir $(OBJDIR) 2>/dev/null)
+
+# Include the dependency files.
+-include $(shell mkdir .dep 2>/dev/null) $(wildcard .dep/*)
+
+# Listing of phony targets.
+.PHONY : all begin finish end sizebefore sizeafter gccversion \
+build elf hex bin eep lss sym coff extcoff \
+clean clean_list program debug gdb-config

--- a/testhal/AVR/EXT/chconf.h
+++ b/testhal/AVR/EXT/chconf.h
@@ -1,0 +1,506 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel related settings and hooks.
+ * @{
+ */
+
+#ifndef _CHCONF_H_
+#define _CHCONF_H_
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#define CH_CFG_ST_RESOLUTION                16
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ */
+#define CH_CFG_ST_FREQUENCY                 15624
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#define CH_CFG_ST_TIMEDELTA                 2
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ *
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ */
+#define CH_CFG_TIME_QUANTUM                 0
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#define CH_CFG_MEMCORE_SIZE                 128
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread automatically. The application has
+ *          then the responsibility to do one of the following:
+ *          - Spawn a custom idle thread at priority @p IDLEPRIO.
+ *          - Change the main() thread priority to @p IDLEPRIO then enter
+ *            an endless loop. In this scenario the @p main() thread acts as
+ *            the idle thread.
+ *          .
+ * @note    Unless an idle thread is spawned the @p main() thread must not
+ *          enter a sleep state.
+ */
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_TM                       FALSE
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_REGISTRY                 TRUE
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_WAITEXIT                 TRUE
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_SEMAPHORES               TRUE
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+
+/**
+ * @brief   Atomic semaphore API.
+ * @details If enabled then the semaphores the @p chSemSignalWait() API
+ *          is included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#define CH_USE_SEMSW                        TRUE
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MUTEXES                  TRUE
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#define CH_CFG_USE_CONDVARS                 TRUE
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_EVENTS                   TRUE
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MESSAGES                 TRUE
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#define CH_CFG_USE_MAILBOXES                TRUE
+
+/**
+ * @brief   I/O Queues APIs.
+ * @details If enabled then the I/O queues APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_QUEUES                   TRUE
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MEMCORE                  FALSE
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#define CH_CFG_USE_HEAP                     FALSE
+
+/**
+ * @brief   C-runtime allocator.
+ * @details If enabled the the heap allocator APIs just wrap the C-runtime
+ *          @p malloc() and @p free() functions.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_HEAP.
+ * @note    The C-runtime may or may not require @p CH_CFG_USE_MEMCORE, see the
+ *          appropriate documentation.
+ */
+#define CH_CFG_USE_MALLOC_HEAP              FALSE
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#define CH_CFG_USE_MEMPOOLS                 FALSE
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#define CH_CFG_USE_DYNAMIC                  FALSE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_STATISTICS                   FALSE
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_ENABLE_CHECKS                FALSE
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the context switch circular trace buffer is
+ *          activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_ENABLE_TRACE                 FALSE
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#define CH_DBG_FILL_THREADS                 FALSE
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p Thread structure that
+ *          counts the system ticks occurred while executing the thread.
+ *
+ * @note    The default is @p TRUE.
+ * @note    This debug option is defaulted to TRUE because it is required by
+ *          some test cases into the test suite.
+ */
+#define CH_DBG_THREADS_PROFILING            FALSE
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p Thread structure.
+ */
+#define THREAD_EXT_FIELDS                                                   \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p chThdInit() API.
+ *
+ * @note    It is invoked from within @p chThdInit() and implicitly from all
+ *          the threads creation APIs.
+ */
+#define THREAD_EXT_INIT_HOOK(tp) {                                          \
+  /* Add threads initialization code here.*/                                \
+}
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @note    It is inserted into lock zone.
+ * @note    It is also invoked when the threads simply return in order to
+ *          terminate.
+ */
+#define THREAD_EXT_EXIT_HOOK(tp) {                                          \
+  /* Add threads finalization code here.*/                                  \
+}
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) {                              \
+  /* Context switch code here.*/                                            \
+}
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() {                                           \
+  /* Idle loop code here.*/                                                 \
+}
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define SYSTEM_TICK_EVENT_HOOK() {                                          \
+  /* System tick event code here.*/                                         \
+}
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define SYSTEM_HALT_HOOK() {                                                \
+  /* System halt code here.*/                                               \
+}
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* _CHCONF_H_ */
+
+/** @} */

--- a/testhal/AVR/EXT/halconf.h
+++ b/testhal/AVR/EXT/halconf.h
@@ -1,0 +1,341 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef _HALCONF_H_
+#define _HALCONF_H_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the TM subsystem.
+ */
+#if !defined(HAL_USE_TM) || defined(__DOXYGEN__)
+#define HAL_USE_TM                  FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                 TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                 FALSE
+#endif
+
+/**
+ * @brief   Enables the EXT subsystem.
+ */
+#if !defined(HAL_USE_EXT) || defined(__DOXYGEN__)
+#define HAL_USE_EXT                 TRUE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                 FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                 FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                 FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI             FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                 FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                 FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL              FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB          FALSE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                 FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                 FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                 FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE          TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY           FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS              TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ *          This option is recommended also if the SPI driver does not
+ *          use a DMA channel and heavily loads the CPU.
+ */
+#if !defined(MMC_NICE_WAITING) || defined(__DOXYGEN__)
+#define MMC_NICE_WAITING            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY              100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT             FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING            TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE      38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 64 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE         16
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 64 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE     256
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION    TRUE
+#endif
+
+#endif /* _HALCONF_H_ */
+
+/** @} */

--- a/testhal/AVR/EXT/main.c
+++ b/testhal/AVR/EXT/main.c
@@ -1,0 +1,103 @@
+/*
+    ChibiOS - HAL - EXT driver example.
+    Copyright (C) 2015 Igor Stoppa <igor.stoppa@gmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+BSEMAPHORE_DECL(sem, 0);
+
+ /*
+  * External Interrupt Callback for direct irqs.
+  */
+void ext_int_isr_cb(EXTDriver *extp, expchannel_t channel) {
+  chSysLockFromISR();
+  if (channel == EXT_INT0_CHANNEL) {
+    chBSemSignalI(&sem);
+  }
+  else if (channel == EXT_INT1_CHANNEL) {
+    chBSemSignalI(&sem);
+  }
+  chSysUnlockFromISR();
+}
+
+ /*
+  * External Interrupt Callback for PC irqs.
+  */
+void ext_pc_isr_cb(EXTDriver *extp, expchannel_t channel) {
+  chSysLockFromISR();
+  chBSemSignalI(&sem);
+  chSysUnlockFromISR();
+}
+
+
+
+ /*
+  * Configuration for EXT/PC interrupts.
+  */
+const EXTConfig ext_cfg = {
+  .channels = {
+    [EXT_INT0_CHANNEL] = {
+      .mode = EXT_CH_MODE_BOTH_EDGES | EXT_CH_MODE_INTERNAL_PULLUP,
+      .cb = ext_int_isr_cb,
+    },
+    [EXT_INT1_CHANNEL] = {
+      .mode = EXT_CH_MODE_BOTH_EDGES | EXT_CH_MODE_INTERNAL_PULLUP,
+      .cb = ext_int_isr_cb,
+    },
+    [PORTC_INDEX] = {
+      .cb = ext_pc_isr_cb,
+    },
+  },
+};
+
+ /*
+  * Semaphore Driven Thread.
+  */
+static WORKING_AREA(waThread2, 32);
+static THD_FUNCTION(Thread2, arg) {
+  (void)arg;
+  while (true) {
+    chBSemWait(&sem);
+    palTogglePad(IOPORT2, PORTB_LED1);
+  }
+}
+
+/*
+ * Application entry point.
+ */
+
+int main(void) {
+  halInit();
+  chSysInit();
+  extStart(&EXTD1, &ext_cfg);
+
+  /* Configure the output appriately. */
+  palClearPad(IOPORT2, PORTB_LED1);
+
+  chThdCreateStatic(waThread2, sizeof(waThread2), NORMALPRIO, Thread2, NULL);
+
+  extChannelEnable(&EXTD1, EXT_INT0_CHANNEL);
+  extChannelEnable(&EXTD1, EXT_INT1_CHANNEL);
+  extChannelEnable(&EXTD1, ext_port_to_channel(C, 0));
+  extChannelEnable(&EXTD1, ext_port_to_channel(C, 1));
+  extChannelEnable(&EXTD1, ext_port_to_channel(C, 2));
+  extChannelEnable(&EXTD1, ext_port_to_channel(C, 3));
+
+  while(TRUE) {
+    chThdSleepMilliseconds(1000);
+  }
+}

--- a/testhal/AVR/EXT/mcuconf.h
+++ b/testhal/AVR/EXT/mcuconf.h
@@ -1,0 +1,89 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef _MCUCONF_H_
+#define _MCUCONF_H_
+
+/*
+ * AVR drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the driver
+ * is enabled in halconf.h.
+ */
+
+/*
+ * ADC driver system settings.
+ */
+#define AVR_ADC_USE_ADC1                   FALSE
+
+/*
+ * CAN driver system settings.
+ */
+
+/*
+ * MAC driver system settings.
+ */
+
+/*
+ * PWM driver system settings.
+ */
+#define AVR_PWM_USE_TIM1                   FALSE
+#define AVR_PWM_USE_TIM2                   FALSE
+#define AVR_PWM_USE_TIM3                   FALSE
+#define AVR_PWM_USE_TIM4                   FALSE
+#define AVR_PWM_USE_TIM5                   FALSE
+
+/*
+ * ICU driver system settings.
+ */
+#define AVR_ICU_USE_TIM1                   FALSE
+#define AVR_ICU_USE_TIM3                   FALSE
+#define AVR_ICU_USE_TIM4                   FALSE
+#define AVR_ICU_USE_TIM5                   FALSE
+
+/*
+ * GPT driver system settings.
+ */
+#define AVR_GPT_USE_TIM1                   FALSE
+#define AVR_GPT_USE_TIM2                   FALSE
+#define AVR_GPT_USE_TIM3                   FALSE
+#define AVR_GPT_USE_TIM4                   FALSE
+#define AVR_GPT_USE_TIM5                   FALSE
+
+/*
+ * SERIAL driver system settings.
+ */
+#define AVR_SERIAL_USE_USART0              TRUE
+#define AVR_SERIAL_USE_USART1              FALSE
+
+/*
+ * I2C driver system settings.
+ */
+#define AVR_I2C_USE_I2C1                   FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define AVR_SPI_USE_SPI1                   FALSE
+#define AVR_SPI_USE_16BIT_POLLED_EXCHANGE  FALSE
+
+/*
+ * EXT driver system settings.
+ */
+#define AVR_EXT_USE_EXT1                    TRUE
+
+#endif /* _MCUCONF_H_ */

--- a/testhal/AVR/EXT/readme.txt
+++ b/testhal/AVR/EXT/readme.txt
@@ -1,0 +1,22 @@
+*****************************************************************************
+** ChibiOS/RT port for Atmel AVR ATmega1280.                                **
+*****************************************************************************
+
+** TARGET **
+
+The demo runs on an Arduino Mega board.
+
+** The Demo **
+
+The demo currently just prints the TestThread output on Serial0, which is
+available on the board USB connector (FT232 converter), and toggles the LED
+on PB7 (pin 13 on Arduino IDE) every second.
+
+** Build Procedure **
+
+The demo was built using the GCC AVR toolchain. It should build with WinAVR too!
+
+** Notes **
+
+This demo runs natively so the Arduino bootloader must be removed and the FUSEs
+reprogrammed. The values used for fuses are LFUSE=0xe7 and HFUSE=0x99.


### PR DESCRIPTION
This PR adds unified support for the external interrupt sources in ATMega chips.
Tested on ATMega328p (Arduino mini pro) with optical end-stop detector as source of interrupts.
The PR also contains an example under the testhal folder.