### PR TITLE
DEMOS: RT: AVR: Optimize out unused sections.

### DIFF
--- a/demos/AVR/RT-ARDUINOMEGA/Makefile
+++ b/demos/AVR/RT-ARDUINOMEGA/Makefile
@@ -152,6 +152,9 @@ CFLAGS += -Wa,-adhlns=$(<:%.c=$(OBJDIR)/%.lst)
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 CFLAGS += $(CSTANDARD)
 CFLAGS += -mrelax
+CFLAGS += -fdata-sections
+CFLAGS += -ffunction-sections
+
 
 #---------------- Compiler Options C++ ----------------
 #  -g*:          generate debugging information
@@ -178,6 +181,9 @@ CFLAGS += -Wundef
 CPPFLAGS += -Wa,-adhlns=$(<:%.cpp=$(OBJDIR)/%.lst)
 CPPFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 #CPPFLAGS += $(CSTANDARD)
+CPPFLAGS += -fdata-sections
+CPPFLAGS += -ffunction-sections
+
 
 #---------------- Assembler Options ----------------
 #  -Wa,...:   tell GCC to pass this to the assembler.
@@ -237,7 +243,7 @@ EXTMEMOPTS =
 #  -Wl,...:     tell GCC to pass this to linker.
 #    -Map:      create map file
 #    --cref:    add cross reference to  map file
-LDFLAGS = -Wl,-Map=$(TARGET).map,--cref
+LDFLAGS = -Wl,-Map=$(TARGET).map,--cref,--gc-sections
 LDFLAGS += $(EXTMEMOPTS)
 LDFLAGS += $(patsubst %,-L%,$(EXTRALIBDIRS))
 LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)

--- a/demos/AVR/RT-ARDUINOUNO/Makefile
+++ b/demos/AVR/RT-ARDUINOUNO/Makefile
@@ -151,6 +151,9 @@ CFLAGS += -Wa,-adhlns=$(<:%.c=$(OBJDIR)/%.lst)
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 CFLAGS += $(CSTANDARD)
 #CFLAGS += -mrelax
+CFLAGS += -fdata-sections
+CFLAGS += -ffunction-sections
+
 
 #---------------- Compiler Options C++ ----------------
 #  -g*:          generate debugging information
@@ -177,6 +180,9 @@ CFLAGS += -Wundef
 CPPFLAGS += -Wa,-adhlns=$(<:%.cpp=$(OBJDIR)/%.lst)
 CPPFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 #CPPFLAGS += $(CSTANDARD)
+CPPFLAGS += -fdata-sections
+CPPFLAGS += -ffunction-sections
+
 
 #---------------- Assembler Options ----------------
 #  -Wa,...:   tell GCC to pass this to the assembler.
@@ -236,7 +242,7 @@ EXTMEMOPTS =
 #  -Wl,...:     tell GCC to pass this to linker.
 #    -Map:      create map file
 #    --cref:    add cross reference to  map file
-LDFLAGS = -Wl,-Map=$(TARGET).map,--cref
+LDFLAGS = -Wl,-Map=$(TARGET).map,--cref,--gc-sections
 LDFLAGS += $(EXTMEMOPTS)
 LDFLAGS += $(patsubst %,-L%,$(EXTRALIBDIRS))
 LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)


### PR DESCRIPTION
For both RT examples, avoid linking those functions and data which
are never used. This both reduces memory occupation and speeds up
flashing.

Signed-off-by: Igor Stopp <igor.stoppa@gmail.com>