### PR TITLE
Bug fix related to chprintf

### DIFF
--- a/os/hal/lib/streams/chprintf.c
+++ b/os/hal/lib/streams/chprintf.c
@@ -27,7 +27,6 @@
  * @{
  */
 
-#include "hal.h"
 #include "chprintf.h"
 #include "memstreams.h"
 

--- a/os/hal/lib/streams/chprintf.h
+++ b/os/hal/lib/streams/chprintf.h
@@ -25,6 +25,7 @@
 #ifndef _CHPRINTF_H_
 #define _CHPRINTF_H_
 
+#include "hal.h"
 #include <stdarg.h>
 
 /**


### PR DESCRIPTION
In file included from ./urosconf.h:49:0,
                 from /Users/spiralray/stm32/uROSnode/src/../include/urosBase.h:45,
                 from /Users/spiralray/stm32/uROSnode/src/urosBase.c:42:
ChibiOS/os/hal/lib/streams/chprintf.h:40:17: error: unknown type name 'BaseSequentialStream'
   int chvprintf(BaseSequentialStream *chp, const char *fmt, va_list ap);
                 ^
ChibiOS/os/hal/lib/streams/chprintf.h:41:16: error: unknown type name 'BaseSequentialStream'
   int chprintf(BaseSequentialStream *chp, const char *fmt, ...);