### PR TITLE
Add CRC clock control to STM32F4xx hal driver

### DIFF
--- a/os/hal/ports/STM32/STM32F4xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32F4xx/stm32_rcc.h
@@ -440,6 +440,38 @@
 /** @} */
 
 /**
+ * @name    CRC peripherals specific RCC operations
+ * @{
+ */
+/**
+ * @brief   Enables the CRC peripheral clock.
+ * @note    The @p lp parameter is ignored in this family.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccEnableCRC(lp) rccEnableAHB(RCC_AHB1ENR_CRCEN, lp)
+
+/**
+ * @brief   Disables the CRC peripheral clock.
+ * @note    The @p lp parameter is ignored in this family.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccDisableCRC(lp) rccDisableAHB(RCC_AHB1ENR_CRCEN, lp)
+
+/**
+ * @brief   Resets the CRC peripheral.
+ *
+ * @api
+ */
+#define rccResetCRC() rccResetAHB(RCC_AHB1RSTR_CRCRST)
+/** @} */
+
+/**
  * @name    PWR interface specific RCC operations
  * @{
  */


### PR DESCRIPTION
This pull request adds macros rccEnableCRC, rccDisableCRC, and rccResetCRC to the
STM32F4xx hal driver simliar to the STM32F0xx driver.

This is needed for interoperation with the ChibiOS-Contrib CRC driver.