### PR TITLE
docs: fix simple typo, trasient -> transient

### DIFF
--- a/os/hal/ports/STM32/LLD/CRYPv1/hal_crypto_lld.c
+++ b/os/hal/ports/STM32/LLD/CRYPv1/hal_crypto_lld.c
@@ -451,7 +451,7 @@ void cry_lld_start(CRYDriver *cryp) {
 #endif
   }
 
-  /* Resetting trasient key data.*/
+  /* Resetting transient key data.*/
   cryp->cryp_ktype = cryp_key_none;
   cryp->cryp_ksize = 0U;
   cryp->cryp_k[0]  = 0U;


### PR DESCRIPTION
There is a small typo in os/hal/ports/STM32/LLD/CRYPv1/hal_crypto_lld.c.

Should read `transient` rather than `trasient`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md