### PR TITLE
Dont thow away serial data when input que is full if hardware flow control is enabled

### DIFF
--- a/os/hal/include/hal_serial.h
+++ b/os/hal/include/hal_serial.h
@@ -213,7 +213,7 @@ struct hal_serial_driver {
  *
  * @api
  */
-#define sdGet(sdp) iqGet(&(sdp)->iqueue)
+#define sdGet(sdp) (sdp)->vmt->gett(sdp, TIME_INFINITE)
 
 /**
  * @brief   Direct read from a @p SerialDriver with timeout specification.
@@ -232,7 +232,7 @@ struct hal_serial_driver {
  *
  * @api
  */
-#define sdGetTimeout(sdp, t) iqGetTimeout(&(sdp)->iqueue, t)
+#define sdGetTimeout(sdp, t) (sdp)->vmt->gett(sdp, t)
 
 /**
  * @brief   Direct non-blocking write to a @p SerialDriver.

--- a/os/hal/include/hal_serial.h
+++ b/os/hal/include/hal_serial.h
@@ -394,7 +394,6 @@ extern "C" {
   bool sdPutWouldBlock(SerialDriver *sdp);
   bool sdGetWouldBlock(SerialDriver *sdp);
   msg_t sdControl(SerialDriver *sdp, unsigned int operation, void *arg);
-  void sdCheckEnableRXInterrupt(SerialDriver *sdp);
 #ifdef __cplusplus
 }
 #endif

--- a/os/hal/include/hal_serial.h
+++ b/os/hal/include/hal_serial.h
@@ -332,7 +332,7 @@ struct hal_serial_driver {
  *
  * @api
  */
-#define sdRead(sdp, b, n) iqReadTimeout(&(sdp)->iqueue, b, n, TIME_INFINITE)
+#define sdRead(sdp, b, n) (sdp)->vmt->readt(sdp, b, n, TIME_INFINITE)
 
 /**
  * @brief   Direct blocking read from a @p SerialDriver with timeout
@@ -353,7 +353,7 @@ struct hal_serial_driver {
  *
  * @api
  */
-#define sdReadTimeout(sdp, b, n, t) iqReadTimeout(&(sdp)->iqueue, b, n, t)
+#define sdReadTimeout(sdp, b, n, t) (sdp)->vmt->readt(sdp, b, n, t)
 
 /**
  * @brief   Direct non-blocking read from a @p SerialDriver.
@@ -370,7 +370,7 @@ struct hal_serial_driver {
  * @api
  */
 #define sdAsynchronousRead(sdp, b, n)                                       \
-  iqReadTimeout(&(sdp)->iqueue, b, n, TIME_IMMEDIATE)
+  (sdp)->vmt->readt(sdp, b, n, TIME_IMMEDIATE)
 /** @} */
 
 /*===========================================================================*/
@@ -394,6 +394,7 @@ extern "C" {
   bool sdPutWouldBlock(SerialDriver *sdp);
   bool sdGetWouldBlock(SerialDriver *sdp);
   msg_t sdControl(SerialDriver *sdp, unsigned int operation, void *arg);
+  void sdCheckEnableRXInterrupt(SerialDriver *sdp);
 #ifdef __cplusplus
 }
 #endif

--- a/os/hal/ports/STM32/LLD/USARTv2/hal_serial_lld.c
+++ b/os/hal/ports/STM32/LLD/USARTv2/hal_serial_lld.c
@@ -867,15 +867,16 @@ void sd_lld_serve_interrupt(SerialDriver *sdp) {
      2) FIFO mode is enabled on devices that support it, we need to empty
         the FIFO.*/
   while (isr & USART_ISR_RXNE) {
-    if (u->CR3 & USART_CR3_RTSE && u->CR3 & USART_CR3_CTSE) {
+    if (u->CR3 & USART_CR3_RTSE) {
+      osalSysLockFromISR();
       if (!iqIsFullI(&sdp->iqueue)) {
-        osalSysLockFromISR();
         sdIncomingDataI(sdp, (uint8_t)u->RDR & sdp->rxmask);
-        osalSysUnlockFromISR();
       } else {
         u->CR1 &= ~(USART_CR1_RXNEIE);
+        osalSysUnlockFromISR();
         break;
       }
+      osalSysUnlockFromISR();
     } else {
       osalSysLockFromISR();
       sdIncomingDataI(sdp, (uint8_t)u->RDR & sdp->rxmask);

--- a/os/hal/ports/STM32/LLD/USARTv2/hal_serial_lld.c
+++ b/os/hal/ports/STM32/LLD/USARTv2/hal_serial_lld.c
@@ -867,9 +867,20 @@ void sd_lld_serve_interrupt(SerialDriver *sdp) {
      2) FIFO mode is enabled on devices that support it, we need to empty
         the FIFO.*/
   while (isr & USART_ISR_RXNE) {
-    osalSysLockFromISR();
-    sdIncomingDataI(sdp, (uint8_t)u->RDR & sdp->rxmask);
-    osalSysUnlockFromISR();
+    if (u->CR3 & USART_CR3_RTSE && u->CR3 & USART_CR3_CTSE) {
+      if (!iqIsFullI(&sdp->iqueue)) {
+        osalSysLockFromISR();
+        sdIncomingDataI(sdp, (uint8_t)u->RDR & sdp->rxmask);
+        osalSysUnlockFromISR();
+      } else {
+        u->CR1 &= ~(USART_CR1_RXNEIE);
+        break;
+      }
+    } else {
+      osalSysLockFromISR();
+      sdIncomingDataI(sdp, (uint8_t)u->RDR & sdp->rxmask);
+      osalSysUnlockFromISR();
+    }
 
     isr = u->ISR;
   }

--- a/os/hal/src/hal_serial.c
+++ b/os/hal/src/hal_serial.c
@@ -47,6 +47,18 @@
  * queue-level function or macro.
  */
 
+void _CheckEnableRXInterrupt(SerialDriver *sdp)
+{
+  USART_TypeDef *u = sdp->usart;
+  const input_queue_t *iq = &sdp->iqueue;
+
+  if ((u->CR3 & USART_CR3_RTSE) && (u->CR3 & USART_CR3_CTSE)) {
+    if (qSpaceI(iq) != qSizeX(iq)) {
+	u->CR1 |= USART_CR1_RXNEIE;
+    }
+  }
+}
+
 static size_t _write(void *ip, const uint8_t *bp, size_t n) {
 
   return oqWriteTimeout(&((SerialDriver *)ip)->oqueue, bp,
@@ -54,7 +66,7 @@ static size_t _write(void *ip, const uint8_t *bp, size_t n) {
 }
 
 static size_t _read(void *ip, uint8_t *bp, size_t n) {
-  sdCheckEnableRXInterrupt((SerialDriver *)ip);
+  _CheckEnableRXInterrupt((SerialDriver *)ip);
   return iqReadTimeout(&((SerialDriver *)ip)->iqueue, bp,
                        n, TIME_INFINITE);
 }
@@ -87,7 +99,7 @@ static size_t _writet(void *ip, const uint8_t *bp, size_t n,
 
 static size_t _readt(void *ip, uint8_t *bp, size_t n,
                      sysinterval_t timeout) {
-  sdCheckEnableRXInterrupt((SerialDriver *)ip);
+  _CheckEnableRXInterrupt((SerialDriver *)ip);
   return iqReadTimeout(&((SerialDriver *)ip)->iqueue, bp, n, timeout);
 }
 
@@ -357,24 +369,6 @@ bool sdGetWouldBlock(SerialDriver *sdp) {
 msg_t sdControl(SerialDriver *sdp, unsigned int operation, void *arg) {
 
   return _ctl((void *)sdp, operation, arg);
-}
-
-/**
- * @brief   Enable RX interrupt when there is space in the input que
- *          if hardware flow control is enabled
- *
- * @param[in] sdp       pointer to a @p SerialDriver object
- */
-void sdCheckEnableRXInterrupt(SerialDriver *sdp)
-{
-  USART_TypeDef *u = sdp->usart;
-  const input_queue_t *iq = &sdp->iqueue;
-
-  if ((u->CR3 & USART_CR3_RTSE) && (u->CR3 & USART_CR3_CTSE)) {
-    if (qSpaceI(iq) != qSizeX(iq)) {
-	u->CR1 |= USART_CR1_RXNEIE;
-    }
-  }
 }
 
 #endif /* HAL_USE_SERIAL == TRUE */


### PR DESCRIPTION
Even when hardware flow control is enabled on the UART the serial RX interrupt will throw away the received data if there is no space left in the input que. In this pull request check if que is full before reading the received byte and if the input que is full the RX interrupt will be disabled. If there is space in the input que the RX interrupt will be enabled again.

This pull request is more of an example on how to fix this issue. Comments are appreciated.