### PR TITLE
USARTv1: fix UART10 clock enable calling rccEnableUART9 instead of rccEnableUART10

### DIFF
--- a/os/hal/ports/STM32/LLD/USARTv1/hal_uart_lld.c
+++ b/os/hal/ports/STM32/LLD/USARTv1/hal_uart_lld.c
@@ -923,7 +923,7 @@ void uart_lld_start(UARTDriver *uartp) {
                                      (void *)uartp);
       osalDbgAssert(uartp->dmatx != NULL, "unable to allocate stream");
 
-      rccEnableUART9(true);
+      rccEnableUART10(true);
       nvicEnableVector(STM32_UART10_NUMBER, STM32_UART_UART10_IRQ_PRIORITY);
       uartp->dmarxmode |= STM32_DMA_CR_CHSEL(UART10_RX_DMA_CHANNEL) |
                           STM32_DMA_CR_PL(STM32_UART_UART10_DMA_PRIORITY);


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in `os/hal/ports/STM32/LLD/USARTv1/hal_uart_lld.c` where `uart_lld_start()` enables the wrong peripheral clock for UART10.

- **Line 926:** `rccEnableUART9(true)` → `rccEnableUART10(true)`

## Problem

In `uart_lld_start()`, the `STM32_UART_USE_UART10` code block calls `rccEnableUART9(true)` instead of `rccEnableUART10(true)`. This sets bit 6 (`RCC_APB2ENR_UART9EN`) instead of bit 7 (`RCC_APB2ENR_UART10EN`) in the `RCC_APB2ENR` register, leaving UART10's peripheral clock disabled.

With the clock disabled, UART10's hardware registers are inaccessible — reads return 0 and writes are ignored. The peripheral is completely non-functional.

### Affected chips

**STM32F413 and STM32F423** — the only STM32F4 sub-families that define `STM32_HAS_UART10 TRUE` (see `os/hal/ports/STM32/STM32F4xx/stm32_registry.h:1601`).

## Root cause

The UART10 initialization block was copied from the UART9 block directly above it, but `rccEnableUART9` on line 926 was never updated to `rccEnableUART10`. Everything else in the block was correctly updated:

| Item | Correctly references UART10? |
|------|------------------------------|
| `#if STM32_UART_USE_UART10` guard | ✅ |
| `&UARTD10 == uartp` check | ✅ |
| Debug assert strings | ✅ |
| DMA stream allocation (`STM32_UART_UART10_*`) | ✅ |
| **`rccEnableUART9(true)`** | **❌ Should be `rccEnableUART10(true)`** |
| `nvicEnableVector(STM32_UART10_NUMBER, ...)` | ✅ |
| DMA channel/priority (`UART10_*_DMA_CHANNEL`) | ✅ |

Further evidence this is a copy-paste error:
- `uart_lld_stop()` at line 1042 correctly calls `rccDisableUART10()`.
- The companion serial driver (`hal_serial_lld.c:641`) correctly calls `rccEnableUART10(true)`.

## Proof from CMSIS headers

From `os/common/ext/ST/STM32F4xx/stm32f413xx.h` (official ST CMSIS headers):

```c
#define RCC_APB2ENR_UART9EN_Pos   (6U)   /* bit 6 → 0x00000040 */
#define RCC_APB2ENR_UART10EN_Pos  (7U)   /* bit 7 → 0x00000080 */
```

These are distinct bits. `rccEnableUART9()` expands to `rccEnableAPB2(RCC_APB2ENR_UART9EN, lp)` which only sets bit 6 — it does **not** enable UART10.

## References

- [RM0430 — STM32F413/423 Reference Manual](https://www.st.com/resource/en/reference_manual/rm0430-stm32f413423-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), Section 6.3.16 (RCC_APB2ENR register)
- [STMicroelectronics/STM32CubeF4#5](https://github.com/STMicroelectronics/STM32CubeF4/issues/5) — A related class of bug where ST's own HAL missed UART9/UART10 in BRR configuration, since these peripherals were late additions to the STM32F4 family
- [ARMmbed/mbed-os#12090](https://github.com/ARMmbed/mbed-os/issues/12090) — Same UART9/UART10 BRR bug in Mbed OS

## Test plan

- [ ] Verify on STM32F413 hardware that UART10 transmits/receives correctly after the fix
- [ ] Verify UART9 still works when both UART9 and UART10 are enabled
- [ ] Code review: confirm no other `rccEnable` calls in USARTv1 have the same mismatch (verified — all others are correct)