### PR TITLE
VFS: fix path normalize treating dotfiles and ..prefix names as special

### DIFF
--- a/os/common/utils/src/paths.c
+++ b/os/common/utils/src/paths.c
@@ -360,7 +360,7 @@ size_t path_normalize(char *dst, const char *src, size_t size) {
     }
 
     /* Handling special cases of "." and "..".*/
-    if (strncmp(dst, "..", 2U) == 0) {
+    if ((ret == 2U) && (strncmp(dst, "..", 2U) == 0)) {
       /* Double dot elements require to remove the last element from
          the output path.*/
       if (n > 1U) {
@@ -376,7 +376,7 @@ size_t path_normalize(char *dst, const char *src, size_t size) {
       }
       continue;
     }
-    else if (strncmp(dst, ".", 1U) == 0) {
+    else if ((ret == 1U) && (*dst == '.')) {
       /* Single dot elements are discarded.*/
       /* Consecutive input separators are consumed.*/
       continue;

--- a/os/vfs/src/vfspaths.c
+++ b/os/vfs/src/vfspaths.c
@@ -357,7 +357,7 @@ size_t vfs_path_normalize(char *dst, const char *src, size_t size) {
     }
 
     /* Handling special cases of "." and "..".*/
-    if (strncmp(dst, "..", 2U) == 0) {
+    if ((ret == 2U) && (strncmp(dst, "..", 2U) == 0)) {
       /* Double dot elements require to remove the last element from
          the output path.*/
       if (n > 1U) {
@@ -373,7 +373,7 @@ size_t vfs_path_normalize(char *dst, const char *src, size_t size) {
       }
       continue;
     }
-    else if (strncmp(dst, ".", 1U) == 0) {
+    else if ((ret == 1U) && (*dst == '.')) {
       /* Single dot elements are discarded.*/
       /* Consecutive input separators are consumed.*/
       continue;


### PR DESCRIPTION
## Summary

Fix `vfs_path_normalize()` and `path_normalize()` using prefix matching instead of exact matching for `.` and `..` path elements, causing dotfiles to be silently dropped and `..`-prefixed names to trigger parent traversal.

**Two-line fix in each of two files:**
- `os/vfs/src/vfspaths.c`, lines 360 and 376
- `os/common/utils/src/paths.c`, lines 363 and 379

## Problem

The `.` and `..` detection uses `strncmp()` which only compares the first N characters:

```c
if (strncmp(dst, "..", 2U) == 0) {          // matches anything starting with ".."
    /* ... parent traversal ... */
}
else if (strncmp(dst, ".", 1U) == 0) {       // matches anything starting with "."
    /* ... discard element ... */
}
```

`strncmp("..foo", "..", 2)` returns 0 (match), and `strncmp(".hidden", ".", 1)` returns 0 (match). The element length (`ret`) is available from the copy_element function but is not checked.

### Proof

Compiled test showing the incorrect matching:

```
..          strncmp(..,2)==0: YES   strncmp(.,1)==0: YES  → TREATED AS ..
..foo       strncmp(..,2)==0: YES   strncmp(.,1)==0: YES  → TREATED AS ..
.           strncmp(..,2)==0: no    strncmp(.,1)==0: YES  → TREATED AS . (DISCARDED)
.hidden     strncmp(..,2)==0: no    strncmp(.,1)==0: YES  → TREATED AS . (DISCARDED)
.ssh        strncmp(..,2)==0: no    strncmp(.,1)==0: YES  → TREATED AS . (DISCARDED)
.config     strncmp(..,2)==0: no    strncmp(.,1)==0: YES  → TREATED AS . (DISCARDED)
normal      strncmp(..,2)==0: no    strncmp(.,1)==0: no   → kept as-is
```

### Impact on paths

| Input path | Expected output | Actual output (before fix) | Problem |
|---|---|---|---|
| `/home/.ssh/keys` | `/home/.ssh/keys` | `/home/keys` | `.ssh` silently dropped |
| `/home/.hidden` | `/home/.hidden` | `/home` | `.hidden` silently dropped |
| `/a/..foo/b` | `/a/..foo/b` | `/b` | `..foo` treated as `..` |
| `/dir/.config/app` | `/dir/.config/app` | `/dir/app` | `.config` silently dropped |
| `/a/.../b` | `/a/.../b` | `/b` | `...` treated as `..` |

### Affected callers

The VFS version (`vfs_path_normalize`) is called from every VFS driver:
- `os/vfs/drivers/overlay/drvoverlay_impl.inc:84`
- `os/vfs/drivers/romfs/drvromfs_impl.inc:60`
- `os/vfs/drivers/littlefs/drvlittlefs_impl.inc:62`
- `vfs_path_make_absolute()` at `os/vfs/src/vfspaths.c:425`

The common utils version (`path_normalize`) is in `os/common/utils/src/paths.c` — a shared utility library.

## Fix

Add `ret` length checks so only exact `.` and `..` elements are handled specially:

```c
// Before:
if (strncmp(dst, "..", 2U) == 0) {
// After:
if ((ret == 2U) && (strncmp(dst, "..", 2U) == 0)) {

// Before:
else if (strncmp(dst, ".", 1U) == 0) {
// After:
else if ((ret == 1U) && (*dst == '.')) {
```

## Test plan

- [ ] Verify `/a/.hidden/b` normalizes to `/a/.hidden/b` (not `/a/b`)
- [ ] Verify `/a/../b` still correctly normalizes to `/b`
- [ ] Verify `/a/./b` still correctly normalizes to `/a/b`
- [ ] Verify `/a/..foo/b` normalizes to `/a/..foo/b` (not `/b`)
- [ ] Verify `/../../../etc` normalizes to `/etc` (root escape still blocked)
- [ ] Verify `/` normalizes to `/`
- [ ] Test with overlay, ROMFS, and LittleFS drivers