### PR TITLE
DACv2: fix DAC2 init reset enabling DAC1 clock instead of DAC2

### DIFF
--- a/os/hal/ports/STM32/LLD/DACv2/hal_dac_lld.c
+++ b/os/hal/ports/STM32/LLD/DACv2/hal_dac_lld.c
@@ -434,7 +434,7 @@ void dac_lld_init(void) {
 #endif
 
 #if STM32_DAC_USE_DAC2_CH1 || STM32_DAC_USE_DAC2_CH2
-  rccEnableDAC1(false);
+  rccEnableDAC2(false);
   rccResetDAC2();
   rccDisableDAC2();
 #endif


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in `os/hal/ports/STM32/LLD/DACv2/hal_dac_lld.c` where `dac_lld_init()` enables DAC1's clock instead of DAC2's clock before resetting DAC2.

- **Line 437:** `rccEnableDAC1(false)` → `rccEnableDAC2(false)`

## Problem

In `dac_lld_init()`, each DAC unit is reset by enabling its clock, issuing a reset, then disabling the clock. The DAC2 block calls `rccEnableDAC1(false)` instead of `rccEnableDAC2(false)`:

```c
/* Used DAC units reset on initialization, note, reset must occur with
   clock enabled.*/
#if STM32_DAC_USE_DAC1_CH1 || STM32_DAC_USE_DAC1_CH2
  rccEnableDAC1(false);    // ✅ Correct
  rccResetDAC1();
  rccDisableDAC1();
#endif

#if STM32_DAC_USE_DAC2_CH1 || STM32_DAC_USE_DAC2_CH2
  rccEnableDAC1(false);    // ❌ BUG: should be rccEnableDAC2(false)
  rccResetDAC2();
  rccDisableDAC2();
#endif

#if STM32_DAC_USE_DAC3_CH1 || STM32_DAC_USE_DAC3_CH2
  rccEnableDAC3(false);    // ✅ Correct
  rccResetDAC3();
  rccDisableDAC3();
#endif

#if STM32_DAC_USE_DAC4_CH1 || STM32_DAC_USE_DAC4_CH2
  rccEnableDAC4(false);    // ✅ Correct
  rccResetDAC4();
  rccDisableDAC4();
#endif
```

As the code comment says: "reset must occur with clock enabled." With the wrong clock enabled, `rccResetDAC2()` operates on an unclocked peripheral, so the reset may not take effect. DAC2 could start in an undefined state.

### Affected chips

STM32 families with multiple DAC units using the DACv2 driver:
- **STM32G4xx** — `RCC_AHB2ENR_DAC1EN` (bit 16) vs `RCC_AHB2ENR_DAC2EN` (bit 17)
- **STM32H5xx** — separate DAC1/DAC2 clock bits on AHB2
- **STM32U5xx** — separate DAC1/DAC2 clock bits on AHB2

## Root cause

The DAC2 block was copied from DAC1 directly above it, but `rccEnableDAC1` was never changed to `rccEnableDAC2`. DAC3 and DAC4 blocks are correct, confirming this is an isolated copy-paste error.

Further evidence:
- `dac_lld_start()` at lines 489/495 correctly calls `rccEnableDAC2(true)`.
- `dac_lld_stop()` at lines 637/646 correctly calls `rccDisableDAC2()`.

## Test plan

- [ ] Verify on STM32G4 hardware that DAC2 outputs correct analog voltage after init
- [ ] Verify DAC1 still works correctly when both DAC1 and DAC2 are enabled
- [ ] Code review: confirm no other `rccEnable` calls in DACv2 have the same mismatch (verified — DAC1, DAC3, DAC4 are all correct, only DAC2 init was wrong)