### PR TITLE
OCTOSPI: fix uninitialized dcr2 variable in wspi_lld_start (v1 and v2)

### DIFF
--- a/os/hal/ports/STM32/LLD/OCTOSPIv1/hal_wspi_lld.c
+++ b/os/hal/ports/STM32/LLD/OCTOSPIv1/hal_wspi_lld.c
@@ -219,7 +219,7 @@ void wspi_lld_init(void) {
  * @notapi
  */
 void wspi_lld_start(WSPIDriver *wspip) {
-  uint32_t dcr2;
+  uint32_t dcr2 = 0U;
 
   /* If in stopped state then full initialization.*/
   if (wspip->state == WSPI_STOP) {

--- a/os/hal/ports/STM32/LLD/OCTOSPIv2/hal_wspi_lld.c
+++ b/os/hal/ports/STM32/LLD/OCTOSPIv2/hal_wspi_lld.c
@@ -147,7 +147,7 @@ void wspi_lld_init(void) {
  * @notapi
  */
 void wspi_lld_start(WSPIDriver *wspip) {
-  uint32_t dcr2;
+  uint32_t dcr2 = 0U;
 
   /* If in stopped state then full initialization.*/
   if (wspip->state == WSPI_STOP) {


### PR DESCRIPTION
## Summary

Fix an uninitialized local variable `dcr2` in `os/hal/ports/STM32/LLD/OCTOSPIv1/hal_wspi_lld.c` that gets OR'd into the OCTOSPI DCR2 register when reconfiguring the driver.

- **Line 222:** `uint32_t dcr2;` → `uint32_t dcr2 = 0U;`

## Problem

In `wspi_lld_start()`, the local variable `dcr2` is only assigned inside the `if (wspip->state == WSPI_STOP)` block (lines 235 and 248). When the driver is being reconfigured without going through STOP state, `dcr2` is **never assigned** but is still used at line 258:

```c
wspip->ospi->DCR2 = wspip->config->dcr2 | dcr2;  // dcr2 is uninitialized!
```

This OR's a garbage stack value into the OCTOSPI DCR2 register (which controls the prescaler among other things), potentially corrupting the OCTOSPI clock frequency and causing communication failures with the flash device.

### Code flow

```c
void wspi_lld_start(WSPIDriver *wspip) {
  uint32_t dcr2;                         // ← NOT initialized

  if (wspip->state == WSPI_STOP) {       // ← Only entered on first start
    ...
    dcr2 = STM32_DCR2_PRESCALER(...);    // ← Only assigned here
    ...
  }

  // Always executed, including on reconfiguration:
  wspip->ospi->DCR2 = wspip->config->dcr2 | dcr2;  // ← BUG: dcr2 may be garbage
}
```

### Affected chips

All STM32 families using OCTOSPIv1 (e.g. STM32L4+, STM32U5).

## Fix

Initialize `dcr2` to `0U`. This matches the XHAL OCTOSPIv2 driver which already initializes it correctly at `os/xhal/ports/STM32/LLD/OCTOSPIv2/hal_wspi_lld.c:131`.

## Found by

`cppcheck --enable=warning` static analysis (`error:uninitvar`).

## Test plan

- [ ] Verify WSPI flash communication works correctly after driver reconfiguration (e.g. `wspiStop()` + `wspiStart()` with same or different config)
- [ ] Verify first-time initialization still works (WSPI_STOP path unchanged)