### PR TITLE
RP2040: fix watchdog tick divisor using self-dividing expression

### DIFF
--- a/os/hal/ports/RP/RP2040/rp_clocks.c
+++ b/os/hal/ports/RP/RP2040/rp_clocks.c
@@ -95,7 +95,7 @@ void rp_clock_init(void) {
   /* Configure tick generator for ~1 us ticks. */
   WATCHDOG->TICK = WATCHDOG_TICK_ENABLE | (RP_ROSC_ASSUMED_HZ / 1000000U);
 
-  /* Clear clock resus that may be in an unkown state */
+  /* Clear clock resus that may be in an unknown state */
   CLOCKS->RESUS.CTRL = 0U;
 
   rp_xosc_init();

--- a/os/hal/ports/RP/RP2040/rp_clocks.c
+++ b/os/hal/ports/RP/RP2040/rp_clocks.c
@@ -93,7 +93,7 @@ void rp_clock_init(void) {
   rp_peripheral_unreset(RESETS_ALLREG_TIMER0);
 
   /* Configure tick generator for ~1 us ticks. */
-  WATCHDOG->TICK = WATCHDOG_TICK_ENABLE | (RP_ROSC_ASSUMED_HZ / RP_ROSC_ASSUMED_HZ);
+  WATCHDOG->TICK = WATCHDOG_TICK_ENABLE | (RP_ROSC_ASSUMED_HZ / 1000000U);
 
   /* Clear clock resus that may be in an unkown state */
   CLOCKS->RESUS.CTRL = 0U;


### PR DESCRIPTION
## Summary

Fix the RP2040 watchdog tick generator divisor which divides `RP_ROSC_ASSUMED_HZ` by itself instead of by `1000000U`.

- **Line 96 of `os/hal/ports/RP/RP2040/rp_clocks.c`:**
  `RP_ROSC_ASSUMED_HZ / RP_ROSC_ASSUMED_HZ` → `RP_ROSC_ASSUMED_HZ / 1000000U`

## Problem

In `rp_clock_init()`, the watchdog tick generator is configured for ~1 µs ticks. The CYCLES field (bits 8:0 of the TICK register) should contain the number of reference clock cycles per microsecond. Instead, it divides the frequency by itself:

```c
/* Configure tick generator for ~1 us ticks. */
WATCHDOG->TICK = WATCHDOG_TICK_ENABLE | (RP_ROSC_ASSUMED_HZ / RP_ROSC_ASSUMED_HZ);
//                                       6000000             / 6000000 = 1 (WRONG!)
```

With `RP_ROSC_ASSUMED_HZ = 6000000` (6 MHz assumed ROSC), this produces CYCLES=**1** instead of CYCLES=**6**, making each tick ~167 ns instead of ~1 µs. The watchdog tick runs **6x too fast**.

### Proof

**Same file, lines 136 and 181** use the correct expression when reconfiguring after XOSC is ready:
```c
WATCHDOG->TICK = WATCHDOG_TICK_ENABLE | (RP_XOSCCLK / 1000000U);  // line 136, CORRECT
```

**RP2350 equivalent** at `os/hal/ports/RP/RP2350/rp_clocks.c:72`:
```c
TICKS->TICK[TICKS_TIMER0].CYCLES = RP_ROSC_ASSUMED_HZ / 1000000U;  // CORRECT
```

**Pico SDK** documentation for `watchdog_start_tick()`:
> "This needs to be a divider that when applied to the XOSC input, produces a 1MHz clock. So if the XOSC is 12MHz, this will need to be 12."

**RP2040 Datasheet** Section 4.7, TICK register: CYCLES (bits 8:0) = "Total number of clk_tick cycles before the next tick."

### Impact

The wrong divisor is active during early boot — between line 96 (ROSC-based tick setup) and line 136 (XOSC-based tick reconfiguration). During this window:
- Clock resus timeouts, PLL lock waits, and XOSC startup timing are ~6x tighter than intended
- If any of these operations takes longer than expected on a marginal board, the too-tight timeout could cause spurious failures
- After line 136 executes, the tick is reconfigured correctly and the bug no longer matters

### Register layout (from `rp2040.h`)

```
WATCHDOG->TICK register (offset 0x2C):
  Bit 10:    RUNNING (read-only)
  Bit  9:    ENABLE  (WATCHDOG_TICK_ENABLE = 0x200)
  Bits 8:0:  CYCLES  (number of clk_ref cycles per tick)
```

## Found by

`cppcheck` static analysis (`style:duplicateExpression` — "Same expression on both sides of '/'").

## References

- [RP2040 Datasheet](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf) — Section 4.7 (Watchdog)
- [Pico SDK watchdog.h](https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_watchdog/include/hardware/watchdog.h)
- [RP2040 watchdog register definitions](https://github.com/majbthrd/pico-debug/blob/master/rp2040/hardware/regs/watchdog.h)

## Test plan

- [ ] Verify on RP2040 hardware that early boot timing is correct
- [ ] Verify PLL lock and XOSC startup still succeed (they worked before, just with tighter margins)