### PR TITLE
MDMAv1: fix missing CBTIF and CTCIF in interrupt clear flag sets

### DIFF
--- a/os/hal/ports/STM32/LLD/MDMAv1/stm32_mdma.c
+++ b/os/hal/ports/STM32/LLD/MDMAv1/stm32_mdma.c
@@ -182,10 +182,10 @@ void mdmaInit(void) {
     mdma.channels[i].channel->CCR   = STM32_MDMA_CCR_RESET_VALUE;
     mdma.channels[i].channel->CTCR  = STM32_MDMA_CTCR_RESET_VALUE;
     mdma.channels[i].channel->CIFCR = STM32_MDMA_CIFCR_CTEIF  |
-                                      STM32_MDMA_CIFCR_CBRTIF |
-                                      STM32_MDMA_CIFCR_CBRTIF |
                                       STM32_MDMA_CIFCR_CCTCIF |
-                                      STM32_MDMA_CIFCR_CTEIF;
+                                      STM32_MDMA_CIFCR_CBRTIF |
+                                      STM32_MDMA_CIFCR_CBTIF  |
+                                      STM32_MDMA_CIFCR_CTCIF;
   }
 }
 

--- a/os/hal/ports/STM32/LLD/MDMAv1/stm32_mdma.h
+++ b/os/hal/ports/STM32/LLD/MDMAv1/stm32_mdma.h
@@ -418,10 +418,10 @@ typedef struct {
  */
 #define mdmaChannelClearInterruptX(mdmachp) do {                            \
   (mdmachp)->channel->CIFCR = (STM32_MDMA_CIFCR_CTEIF  |                    \
-                               STM32_MDMA_CIFCR_CBRTIF |                    \
-                               STM32_MDMA_CIFCR_CBRTIF |                    \
                                STM32_MDMA_CIFCR_CCTCIF |                    \
-                               STM32_MDMA_CIFCR_CTEIF);                     \
+                               STM32_MDMA_CIFCR_CBRTIF |                    \
+                               STM32_MDMA_CIFCR_CBTIF  |                    \
+                               STM32_MDMA_CIFCR_CTCIF);                     \
 } while (0)
 
 /**


### PR DESCRIPTION
## Summary

Fix duplicated and missing MDMA interrupt clear flags in `mdmaInit()` and the `mdmaChannelClearInterruptX()` macro.

**Files:**
- `os/hal/ports/STM32/LLD/MDMAv1/stm32_mdma.c` (line 184)
- `os/hal/ports/STM32/LLD/MDMAv1/stm32_mdma.h` (line 420)

## Problem

The MDMA CIFCR (Channel Interrupt Flag Clear Register) has **5** interrupt clear bits, but only **3** unique flags were being written — two were duplicated:

```c
// Before (both locations):
channel->CIFCR = STM32_MDMA_CIFCR_CTEIF  |    // bit 0 ✓
                 STM32_MDMA_CIFCR_CBRTIF |    // bit 2 ✓
                 STM32_MDMA_CIFCR_CBRTIF |    // bit 2 ← DUPLICATE
                 STM32_MDMA_CIFCR_CCTCIF |    // bit 1 ✓
                 STM32_MDMA_CIFCR_CTEIF;      // bit 0 ← DUPLICATE
```

**Missing flags:**
- `STM32_MDMA_CIFCR_CBTIF` (bit 3) — Block Transfer interrupt clear
- `STM32_MDMA_CIFCR_CTCIF` (bit 4) — Transfer Complete interrupt clear

### CIFCR register layout (from `stm32_mdma.h`)

```c
#define STM32_MDMA_CIFCR_CTEIF      (1U << 0)   // Transfer Error
#define STM32_MDMA_CIFCR_CCTCIF     (1U << 1)   // Channel Transfer Complete
#define STM32_MDMA_CIFCR_CBRTIF     (1U << 2)   // Block Repeat Transfer
#define STM32_MDMA_CIFCR_CBTIF      (1U << 3)   // Block Transfer       ← MISSING
#define STM32_MDMA_CIFCR_CTCIF      (1U << 4)   // Transfer Complete    ← MISSING
```

### Impact

Block Transfer (CBTIF) and Transfer Complete (CTCIF) interrupt flags are never cleared:
- During `mdmaInit()`: stale flags from before reset could remain set
- Via `mdmaChannelClearInterruptX()`: after an MDMA operation completes, these flags persist and could trigger spurious interrupt callbacks on the next transfer

Affects all STM32H7xx devices using MDMA (e.g. for OCTOSPI, SDMMC, or memory-to-memory transfers).

## Fix

Replace the duplicated flags with the two missing ones:

```c
// After:
channel->CIFCR = STM32_MDMA_CIFCR_CTEIF  |    // bit 0 ✓
                 STM32_MDMA_CIFCR_CCTCIF |    // bit 1 ✓
                 STM32_MDMA_CIFCR_CBRTIF |    // bit 2 ✓
                 STM32_MDMA_CIFCR_CBTIF  |    // bit 3 ✓ (was missing)
                 STM32_MDMA_CIFCR_CTCIF;      // bit 4 ✓ (was missing)
```

## Found by

`cppcheck` static analysis (`style:duplicateExpression`).

## Test plan

- [ ] Verify MDMA operations (e.g. OCTOSPI flash access) work correctly on STM32H7
- [ ] Verify no spurious MDMA interrupts after transfer completion