### PR TITLE
DACv1: fix wrong DMA peripheral size in 8-bit mode

### DIFF
--- a/os/hal/ports/STM32/LLD/DACv1/hal_dac_lld.c
+++ b/os/hal/ports/STM32/LLD/DACv1/hal_dac_lld.c
@@ -752,7 +752,7 @@ void dac_lld_start_conversion(DACDriver *dacp) {
 #if STM32_DMA_ADVANCED == FALSE
               STM32_DMA_CR_PSIZE_WORD  | STM32_DMA_CR_MSIZE_BYTE;
 #else
-              STM32_DMA_CR_MSIZE_BYTE  | STM32_DMA_CR_MSIZE_BYTE;
+              STM32_DMA_CR_PSIZE_BYTE  | STM32_DMA_CR_MSIZE_BYTE;
 #endif
 
     /* In this mode the size of the buffer is halved because two samples


### PR DESCRIPTION
## Summary

- Fix copy-paste error in `dac_lld_start_conversion()` where `STM32_DMA_CR_MSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE` should be `STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE` in the `DAC_DHRM_8BIT_RIGHT` case when `STM32_DMA_ADVANCED == TRUE`
- The MSIZE (Memory SIZE) macro appears twice while PSIZE (Peripheral SIZE) is absent

## Details

In `os/hal/ports/STM32/LLD/DACv1/hal_dac_lld.c` line 755, the DMA mode for 8-bit DAC output on advanced DMA controllers duplicates `STM32_DMA_CR_MSIZE_BYTE` instead of using `STM32_DMA_CR_PSIZE_BYTE` for the first operand.

The pattern from the 12-bit cases in the same switch statement is clear:

| Data mode | `STM32_DMA_ADVANCED == FALSE` | `STM32_DMA_ADVANCED == TRUE` |
|---|---|---|
| 12BIT_RIGHT (line 729/731) | `PSIZE_WORD \| MSIZE_HWORD` | `PSIZE_HWORD \| MSIZE_HWORD` |
| 12BIT_LEFT (line 741/743) | `PSIZE_WORD \| MSIZE_HWORD` | `PSIZE_HWORD \| MSIZE_HWORD` |
| 8BIT_RIGHT (line 753/755) | `PSIZE_WORD \| MSIZE_BYTE` | **`MSIZE_BYTE \| MSIZE_BYTE`** (BUG) |

Non-advanced DMA always uses `PSIZE_WORD` regardless of data width. Advanced DMA uses the actual peripheral data size (`PSIZE_HWORD` for 12-bit, should be `PSIZE_BYTE` for 8-bit).

### Current runtime impact

Both `STM32_DMA_CR_PSIZE_BYTE` and `STM32_DMA_CR_MSIZE_BYTE` are defined as `0` in both `DMAv1/stm32_dma.h:228,232` and `DMAv2/stm32_dma.h:189,193`, so `MSIZE_BYTE | MSIZE_BYTE` = `0 | 0` = `0` = `PSIZE_BYTE | MSIZE_BYTE`. The computed value is identical, so there is **no runtime behavioral change**. However, the code is semantically wrong and would break if the DMA size defines were ever reorganized.

### Affected platforms

STM32F2/F4/F7/H7 and other families with advanced DMA (`STM32_DMA_ADVANCED == TRUE`) using the DACv1 driver in 8-bit right-aligned output mode.

## Test plan

- [ ] Verify the fix compiles cleanly for an STM32F4/F7/H7 target using DACv1
- [ ] Verify 8-bit DAC output still works correctly (no behavioral change expected)