### PR TITLE
GPDMAv1: fix typo in STM32_GPDMA_MASK_FIFO4_2D macro name

### DIFF
--- a/os/hal/ports/STM32/LLD/GPDMAv1/stm32_gpdma.h
+++ b/os/hal/ports/STM32/LLD/GPDMAv1/stm32_gpdma.h
@@ -344,7 +344,7 @@
 /**
  * @brief   Any FIFO4_2D channel on any GPDMA.
  */
-#define STM32_GPDMAX_MASK_FIFO4_2D                                          \
+#define STM32_GPDMA_MASK_FIFO4_2D                                          \
   (STM32_GPDMA1_MASK_FIFO4_2D | STM32_GPDMA2_MASK_FIFO4_2D)
 
 /**


### PR DESCRIPTION
## Summary

- Fix typo in macro name: `STM32_GPDMAX_MASK_FIFO4_2D` → `STM32_GPDMA_MASK_FIFO4_2D` (stray 'X' in name)
- The macro is the combined GPDMA1+GPDMA2 mask for FIFO4_2D channels

## Details

In `os/hal/ports/STM32/LLD/GPDMAv1/stm32_gpdma.h` line 347, the macro name `STM32_GPDMAX_MASK_FIFO4_2D` has a stray 'X' that makes it inconsistent with all other combined masks in the same file:

| Line | Macro name | Pattern |
|------|-----------|---------|
| 335 | `STM32_GPDMA_MASK_FIFO2` | ✓ `GPDMA` |
| 341 | `STM32_GPDMA_MASK_FIFO4` | ✓ `GPDMA` |
| **347** | **`STM32_GPDMAX_MASK_FIFO4_2D`** | **✗ `GPDMAX`** |
| 365 | `STM32_GPDMA_MASK_FIFOX` | ✓ `GPDMA` |
| 383 | `STM32_GPDMA_MASK_ANY` | ✓ `GPDMA` |

The per-unit macros (`STM32_GPDMA1_MASK_xxx`, `STM32_GPDMA2_MASK_xxx`) are all correct. Only the combined macro at line 347 has the wrong name.

### Impact

The macro is currently unused in the codebase, but any driver or user code trying to allocate a FIFO4_2D capable channel on any GPDMA unit via the expected name `STM32_GPDMA_MASK_FIFO4_2D` would get a compilation error (undefined macro).

Affects STM32H5xx and other families using the GPDMAv1 driver.

## Test plan

- [ ] Verify the fix compiles for an STM32H5xx target
- [ ] Grep for any usage of the old `STM32_GPDMAX_MASK_FIFO4_2D` name (none expected)