### PR TITLE
sb: fix unsigned integer underflow in sb_check_strings_array()

### DIFF
--- a/os/sb/host/sbregions.c
+++ b/os/sb/host/sbregions.c
@@ -119,6 +119,9 @@ size_t sb_check_strings_array(sb_class_t *sbp, const char *pp[], size_t max) {
     while ((s = *pp++) != NULL) {
       size_t sn;
 
+      if (n >= max) {
+        return (size_t)0;
+      }
       sn = sb_check_string(sbp, s, max - n);
       if (sn == (size_t)0) {
         return (size_t)0;


### PR DESCRIPTION
## Summary

- Fix unsigned integer underflow in `sb_check_strings_array()` where `max - n` wraps when `n > max`
- One-line guard added before the subtraction in sandbox pointer validation code

## Details

In `os/sb/host/sbregions.c`, function `sb_check_strings_array()` validates an array of string pointers from sandboxed code. The variable `n` accumulates the total validated size:

```c
n = sb_check_pointers_array(sbp, (const void **)pp, max);  // initial size
...
while ((s = *pp++) != NULL) {
    sn = sb_check_string(sbp, s, max - n);  // BUG: underflow if n > max
    ...
    n += sn;  // n grows with each string
}
```

If the pointers array plus the first few strings exceed `max`, then `n > max` and `max - n` wraps to `SIZE_MAX - (n - max)` (a very large value) because both are `size_t` (unsigned). This passes an effectively unlimited length to `sb_check_string()`, bypassing the `max` safety bound.

### Impact

While `sb_check_string()` independently validates that each string falls within a valid sandbox memory region, the `max` parameter is a secondary safety bound meant to limit total scanning. The underflow defeats this limit.

This is security-critical sandbox validation code — the function is called from `sbposix.c` to validate user-provided `argv` and `envp` arrays in `sbExec*()` syscalls.

### Fix

Add `if (n >= max) return 0;` before the subtraction.

## Test plan

- [ ] Verify sandbox `exec` syscalls still work with normal argument arrays
- [ ] Verify that very large argument arrays (where total size exceeds `max`) are correctly rejected