### PR TITLE
rt: apply wflags mask inside lock in chEvtGetAndClearFlags()

### DIFF
--- a/os/rt/src/chevents.c
+++ b/os/rt/src/chevents.c
@@ -318,11 +318,11 @@ eventflags_t chEvtGetAndClearFlags(event_listener_t *elp) {
   chDbgCheck(elp != NULL);
 
   chSysLock();
-  flags = elp->flags;
+  flags = elp->flags & elp->wflags;
   elp->flags = (eventflags_t)0;
   chSysUnlock();
 
-  return flags & elp->wflags;
+  return flags;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Move `elp->wflags` mask operation inside the critical section in `chEvtGetAndClearFlags()`
- Makes the API-class function consistent with the I-class `chEvtGetAndClearFlagsI()`

## Details

In `os/rt/src/chevents.c`, `chEvtGetAndClearFlags()` reads `elp->wflags` **after** releasing the system lock:

```c
chSysLock();
flags = elp->flags;
elp->flags = (eventflags_t)0;
chSysUnlock();

return flags & elp->wflags;  // wflags read outside lock
```

If another thread concurrently unregisters and re-registers the same `event_listener_t` object (e.g. with different `wflags`), the `elp->wflags` read at return time could see a value inconsistent with the `elp->flags` that was read inside the lock.

The I-class version `chEvtGetAndClearFlagsI()` (line 292) applies the mask while the caller holds the lock, so both fields are read atomically. The API-class version should do the same.

### Fix

```c
chSysLock();
flags = elp->flags & elp->wflags;  // mask applied inside lock
elp->flags = (eventflags_t)0;
chSysUnlock();

return flags;
```

## Test plan

- [ ] Verify event flag behavior is unchanged for normal single-threaded listener usage
- [ ] Verify correctness under concurrent listener re-registration (if applicable)