### PR TITLE
various: remove stray double semicolons

### DIFF
--- a/os/hal/ports/AVR/XMEGA/LLD/SYSTICKv1/hal_st_lld.h
+++ b/os/hal/ports/AVR/XMEGA/LLD/SYSTICKv1/hal_st_lld.h
@@ -120,7 +120,7 @@ static inline void st_lld_stop_alarm(void) {
  */
 static inline void st_lld_set_alarm(systime_t time) {
 
-  TCC0.PER       = (uint16_t) time;;
+  TCC0.PER       = (uint16_t) time;
 }
 
 /**

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -69,7 +69,7 @@ void rp_clock_init(void) {
   rp_peripheral_unreset(RESETS_ALLREG_TIMER0);
 
   /* Configure tick generator for ~1 us ticks. */
-  TICKS->TICK[TICKS_TIMER0].CYCLES = RP_ROSC_ASSUMED_HZ / 1000000U;;
+  TICKS->TICK[TICKS_TIMER0].CYCLES = RP_ROSC_ASSUMED_HZ / 1000000U;
   TICKS->TICK[TICKS_TIMER0].CTRL = TICKS_CTRL_ENABLE;
 
   /* Clear clock resus that may be in an unkown state */

--- a/os/nil/src/ch.c
+++ b/os/nil/src/ch.c
@@ -92,7 +92,7 @@ thread_t *nil_find_thread(tstate_t state, void *p) {
  * @notapi
  */
 cnt_t nil_ready_all(void *p, cnt_t cnt, msg_t msg) {
-  thread_t *tp = nil.threads;;
+  thread_t *tp = nil.threads;
 
   while (cnt < (cnt_t)0) {
 

--- a/os/sb/apps/msh/main.c
+++ b/os/sb/apps/msh/main.c
@@ -134,7 +134,7 @@ static bool shell_getline(char *line, size_t size) {
   int seq;
 
   state.history_current = state.history_head;
-  seq = 0;;
+  seq = 0;
   while (true) {
     char c;
 


### PR DESCRIPTION
## Summary

Remove extraneous trailing semicolons (`;;`) in four files across NIL kernel, sandbox shell, RP2350 HAL, and AVR XMEGA HAL.

## Files changed

- `os/nil/src/ch.c:95` — `nil_ready_all()`
- `os/sb/apps/msh/main.c:137` — `shell_getline()`
- `os/hal/ports/RP/RP2350/rp_clocks.c:72` — `rp_clock_init()`
- `os/hal/ports/AVR/XMEGA/LLD/SYSTICKv1/hal_st_lld.h:123` — `st_lld_set_alarm()`

No behavioral change.