### PR TITLE
various: fix typos and doc comment mismatches

### DIFF
--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -72,7 +72,7 @@ void rp_clock_init(void) {
   TICKS->TICK[TICKS_TIMER0].CYCLES = RP_ROSC_ASSUMED_HZ / 1000000U;;
   TICKS->TICK[TICKS_TIMER0].CTRL = TICKS_CTRL_ENABLE;
 
-  /* Clear clock resus that may be in an unkown state */
+  /* Clear clock resus that may be in an unknown state */
   CLOCKS->RESUS.CTRL = 0U;
 
   rp_xosc_init();

--- a/os/hal/ports/STM32/STM32H5xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32H5xx/stm32_rcc.h
@@ -199,7 +199,7 @@
 /**
  * @brief   Disables the clock of one or more peripheral on the APB3 bus.
  *
- * @param[in] mask      APB2 peripherals mask
+ * @param[in] mask      APB3 peripherals mask
  *
  * @api
  */

--- a/os/hal/ports/STM32/STM32U3xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32U3xx/stm32_rcc.h
@@ -199,7 +199,7 @@
 /**
  * @brief   Disables the clock of one or more peripheral on the APB3 bus.
  *
- * @param[in] mask      APB2 peripherals mask
+ * @param[in] mask      APB3 peripherals mask
  *
  * @api
  */

--- a/os/hal/ports/STM32/STM32U5xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_rcc.h
@@ -199,7 +199,7 @@
 /**
  * @brief   Disables the clock of one or more peripheral on the APB3 bus.
  *
- * @param[in] mask      APB2 peripherals mask
+ * @param[in] mask      APB3 peripherals mask
  *
  * @api
  */


### PR DESCRIPTION
## Summary

Fix comment typos and documentation mismatches in RP and STM32 HAL code.

## Changes

**Typo "unkown" → "unknown":**
- `os/hal/ports/RP/RP2040/rp_clocks.c:98`
- `os/hal/ports/RP/RP2350/rp_clocks.c:75`

**`rccDisableAPB3()` @param says "APB2" instead of "APB3":**
- `os/hal/ports/STM32/STM32H5xx/stm32_rcc.h:202`
- `os/hal/ports/STM32/STM32U5xx/stm32_rcc.h:202`
- `os/hal/ports/STM32/STM32U3xx/stm32_rcc.h:202`

The APB2/APB3 mismatch was likely copied from the `rccDisableAPB2` macro above when adding APB3 support.

No behavioral change.