### PR TITLE
hal: use if instead of while in oqPutI()

### DIFF
--- a/os/hal/src/hal_queues.c
+++ b/os/hal/src/hal_queues.c
@@ -492,7 +492,7 @@ msg_t oqPutI(output_queue_t *oqp, uint8_t b) {
   osalDbgCheckClassI();
 
   /* Queue space check.*/
-  while (!oqIsFullI(oqp)) {
+  if (!oqIsFullI(oqp)) {
     /* Putting the character into the queue.*/
     oqp->q_counter--;
     *oqp->q_wrptr++ = b;


### PR DESCRIPTION
## Summary

Change `while` to `if` in `oqPutI()` — the loop body unconditionally returns, so it executes at most once.

## Details

In `os/hal/src/hal_queues.c:495`, `oqPutI()` uses:
```c
while (!oqIsFullI(oqp)) {
    ...
    return MSG_OK;
}
return MSG_TIMEOUT;
```

The `return MSG_OK` at line 508 means the loop never iterates. The equivalent `iqPutI()` at line 229 already uses `if`. This change makes `oqPutI()` consistent.

No behavioral change.