### PR TITLE
CANv1: fix wrong peripheral name in ISR doxygen comments

### DIFF
--- a/os/hal/ports/STM32/LLD/CANv1/hal_can_lld.c
+++ b/os/hal/ports/STM32/LLD/CANv1/hal_can_lld.c
@@ -424,7 +424,7 @@ OSAL_IRQ_HANDLER(STM32_CAN1_SCE_HANDLER) {
 #if STM32_CAN_USE_CAN2 || defined(__DOXYGEN__)
 #if defined(STM32_CAN2_UNIFIED_HANDLER)
 /**
- * @brief   CAN1 unified interrupt handler.
+ * @brief   CAN2 unified interrupt handler.
  *
  * @isr
  */
@@ -515,7 +515,7 @@ OSAL_IRQ_HANDLER(STM32_CAN2_SCE_HANDLER) {
 #if STM32_CAN_USE_CAN3 || defined(__DOXYGEN__)
 #if defined(STM32_CAN3_UNIFIED_HANDLER)
 /**
- * @brief   CAN1 unified interrupt handler.
+ * @brief   CAN3 unified interrupt handler.
  *
  * @isr
  */
@@ -574,7 +574,7 @@ OSAL_IRQ_HANDLER(STM32_CAN3_RX0_HANDLER) {
 }
 
 /**
- * @brief   CAN1 RX3 interrupt handler.
+ * @brief   CAN3 RX1 interrupt handler.
  *
  * @isr
  */
@@ -588,7 +588,7 @@ OSAL_IRQ_HANDLER(STM32_CAN3_RX1_HANDLER) {
 }
 
 /**
- * @brief   CAN1 SCE interrupt handler.
+ * @brief   CAN3 SCE interrupt handler.
  *
  * @isr
  */


### PR DESCRIPTION
## Summary

Fix `@brief` comments in CAN2 and CAN3 ISR handlers that say "CAN1" due to copy-paste from the CAN1 block.

## Changes

In `os/hal/ports/STM32/LLD/CANv1/hal_can_lld.c`:

| Line | Before | After |
|------|--------|-------|
| 427 | `CAN1 unified interrupt handler` | `CAN2 unified interrupt handler` |
| 518 | `CAN1 unified interrupt handler` | `CAN3 unified interrupt handler` |
| 577 | `CAN1 RX3 interrupt handler` | `CAN3 RX1 interrupt handler` |
| 591 | `CAN1 SCE interrupt handler` | `CAN3 SCE interrupt handler` |

Line 577 also fixes "RX3" → "RX1" (the handler is `STM32_CAN3_RX1_HANDLER`).

No behavioral change.