### PR TITLE
rt: fix inconsistent overflow assertion in chTimeI2US()

### DIFF
--- a/os/rt/include/chtime.h
+++ b/os/rt/include/chtime.h
@@ -423,7 +423,7 @@ static inline time_usecs_t chTimeI2US(sysinterval_t interval) {
            (time_conv_t)CH_CFG_ST_FREQUENCY - (time_conv_t)1) /
           (time_conv_t)CH_CFG_ST_FREQUENCY;
 
-  chDbgAssert(usecs <= (time_conv_t)((time_usecs_t)-1),
+  chDbgAssert(usecs < (time_conv_t)((time_usecs_t)-1),
               "conversion overflow");
 
   return (time_usecs_t)usecs;


### PR DESCRIPTION
## Summary

- `chTimeI2US()` uses `<=` in its `chDbgAssert` overflow check, while the identical sibling functions `chTimeI2S()` and `chTimeI2MS()` both use `<`. This one-character inconsistency means the microseconds conversion has a weaker overflow guard than the seconds and milliseconds conversions.

## Detail

The three interval-to-time conversion functions in `chtime.h` all perform the same kind of operation: convert a `sysinterval_t` to a narrower time type (`time_secs_t`, `time_msecs_t`, `time_usecs_t`) via a `time_conv_t` intermediate, then assert the result fits.

| Function | Line | Operator | Guards against `(type)-1`? |
|---|---|---|---|
| `chTimeI2S()` | 380 | `<` | Yes |
| `chTimeI2MS()` | 403 | `<` | Yes |
| `chTimeI2US()` | 426 | `<=` | **No** |

With `<=`, `chTimeI2US()` allows the result `(time_usecs_t)-1` (`0xFFFFFFFF` for 32-bit types) to pass silently. The other two functions trap this as an overflow. This inconsistency means:

1. **Weaker safety check** — in debug builds, an edge-case overflow in the microseconds path goes undetected while the equivalent overflow in seconds or milliseconds correctly halts with an assertion.
2. **Potential for misinterpretation** — the maximum unsigned value is commonly reserved as a sentinel or error indicator; allowing it through one conversion path but not the others creates ambiguous behavior.

## Fix

Change `<=` to `<` in `chTimeI2US()` to match `chTimeI2S()` and `chTimeI2MS()`, making all three functions apply the same overflow guard uniformly.

## Test plan

- [ ] Verify `chTimeI2US()` now asserts on a conversion result equal to `(time_usecs_t)-1` in a debug build
- [ ] Verify `chTimeI2US()` continues to pass valid conversions (result < max value)
- [ ] Confirm no change in release builds (assertions compiled out)