### PR TITLE
DMAv1/v2: add osalDbgAssert for NDTR/CNDTR size exceeding 65535

### DIFF
--- a/os/hal/ports/STM32/LLD/DMAv1/stm32_dma.h
+++ b/os/hal/ports/STM32/LLD/DMAv1/stm32_dma.h
@@ -393,6 +393,8 @@ typedef struct {
  * @special
  */
 #define dmaStreamSetTransactionSize(dmastp, size) {                         \
+  osalDbgAssert((uint32_t)(size) <= STM32_DMA_MAX_TRANSFER,                 \
+                "DMA transfer size exceeds CNDTR limit (65535)");            \
   (dmastp)->channel->CNDTR = (uint32_t)(size);                              \
 }
 

--- a/os/hal/ports/STM32/LLD/DMAv2/stm32_dma.h
+++ b/os/hal/ports/STM32/LLD/DMAv2/stm32_dma.h
@@ -497,6 +497,8 @@ typedef struct {
  * @special
  */
 #define dmaStreamSetTransactionSize(dmastp, size) {                         \
+  osalDbgAssert((uint32_t)(size) <= STM32_DMA_MAX_TRANSFER,                 \
+                "DMA transfer size exceeds NDTR limit (65535)");             \
   (dmastp)->stream->NDTR  = (uint32_t)(size);                               \
 }
 


### PR DESCRIPTION
## Problem

`STM32_DMA_MAX_TRANSFER` (65535) is defined in both `DMAv1/stm32_dma.h` and `DMAv2/stm32_dma.h` documenting the 16-bit hardware limit of the NDTR/CNDTR register, but `dmaStreamSetTransactionSize()` never enforces it.

Passing a `size` > 65535 silently truncates the register write:

| size | NDTR/CNDTR written | Actual transfer |
|------|--------------------|----------------|
| 65536 | 0 | zero elements (no data transferred) |
| 131073 | 1 | 1 element instead of 131073 |

Both produce **silent data loss** with no diagnostic.

This was found while building Rust safety wrappers for ChibiOS peripherals and writing parity tests against the C source behaviour. The issue is also documented in ChibiOS-Contrib issue [ChibiOS/ChibiOS-Contrib#164](https://github.com/ChibiOS/ChibiOS-Contrib/issues/164) (CRCv1 large datasets via DMA), where the workaround clamps to `0xFFFF` rather than rejecting the value.

## Fix

Add `osalDbgAssert((uint32_t)(size) <= STM32_DMA_MAX_TRANSFER, ...)` inside the macro body, immediately before the register write — consistent with the existing BRR range check pattern in `hal_serial_lld.c`:

```c
osalDbgAssert(brr < 0x10000, "invalid BRR value");
```

**DMAv2** (`stream->NDTR`):
```c
#define dmaStreamSetTransactionSize(dmastp, size) {
  osalDbgAssert((uint32_t)(size) <= STM32_DMA_MAX_TRANSFER,
                "DMA transfer size exceeds NDTR limit (65535)");
  (dmastp)->stream->NDTR  = (uint32_t)(size);
}
```

**DMAv1** (`channel->CNDTR`): same pattern.

## Notes

- **GPDMAv1 is not affected**: its block-count register is 32-bit (BCR field); the 65535 limit does not apply.
- **Release builds**: `osalDbgAssert` compiles to nothing in release; this is a debug-time trap only, consistent with ChibiOS convention.
- **No API change**: the macro signature is unchanged.