### PR TITLE
USARTv1/v2: add osalDbgAssert for speed == 0 in usart_init

### DIFF
--- a/os/hal/ports/STM32/LLD/USARTv1/hal_serial_lld.c
+++ b/os/hal/ports/STM32/LLD/USARTv1/hal_serial_lld.c
@@ -112,6 +112,7 @@ static void usart_init(SerialDriver *sdp, const SerialConfig *config) {
   uint32_t brr;
   USART_TypeDef *u = sdp->usart;
 
+  osalDbgAssert(config->speed != 0U, "invalid baud rate (zero)");
   brr = (uint32_t)((sdp->clock + config->speed/2) / config->speed);
 
 #if defined(USART_CR1_OVER8)

--- a/os/hal/ports/STM32/LLD/USARTv2/hal_serial_lld.c
+++ b/os/hal/ports/STM32/LLD/USARTv2/hal_serial_lld.c
@@ -235,6 +235,7 @@ static void usart_init(SerialDriver *sdp,
   USART_TypeDef *u = sdp->usart;
 
   /* Baud rate setting.*/
+  osalDbgAssert(config->speed != 0U, "invalid baud rate (zero)");
   clock = sdp->clock;
 #if STM32_SERIAL_USE_LPUART1
   if (sdp == &LPSD1) {


### PR DESCRIPTION
## Problem

In both `USARTv1/hal_serial_lld.c` and `USARTv2/hal_serial_lld.c`, the `usart_init()` function divides by `config->speed` to compute the BRR register without first checking it is non-zero:

```c
/* USARTv1 */
brr = (uint32_t)((sdp->clock + config->speed/2) / config->speed);

/* USARTv2 standard path */
brr = (uint32_t)((clock + config->speed / 2) / config->speed);

/* USARTv2 LPUART1 path */
brr = (uint32_t)(((uint64_t)clock * 256 + config->speed/2) / config->speed);
```

Passing `speed = 0` triggers **integer division-by-zero**, which is undefined behaviour in C (ISO C11 §6.5.5 ¶5). Depending on CPU and toolchain this may: cause a HardFault trap, return garbage leaving the USART misconfigured, or be silently optimised away.

The USARTv2 LPUART path is additionally affected through the range check `clock >= config->speed * 3U`: when `speed = 0`, the multiplication evaluates to 0 and the assert passes vacuously, not catching the error.

This was identified while building Rust safety wrappers for ChibiOS peripherals and writing parity tests comparing C driver behaviour against the Rust implementation.

## Fix

Add `osalDbgAssert(config->speed != 0U, "invalid baud rate (zero)")` at the top of the baud-rate calculation section, before any arithmetic on `config->speed`. Placement and style are identical to the existing BRR range validation:

```c
osalDbgAssert(brr < 0x10000, "invalid BRR value");
```

## Notes

- **Debug-only**: `osalDbgAssert` compiles away in release builds. A release build with `speed = 0` continues to have undefined behaviour; this is consistent with how ChibiOS handles other parameter preconditions.
- **`hal_uart_lld.c` is not included** in this patch: the UART HAL driver does not use `config->speed` directly for BRR; baud rate comes from the `SerialConfig` passed to the serial driver. A separate audit of `hal_uart_lld.c` may be warranted.
- **No API change**.