### PR TITLE
RP2040: correct four register bitfield definitions

### DIFF
--- a/os/common/ext/RP/RP2040/rp2040.h
+++ b/os/common/ext/RP/RP2040/rp2040.h
@@ -2144,7 +2144,7 @@ typedef struct {
 #define UART_UARTLCR_H_SPS_Msk            (1U << UART_UARTLCR_H_SPS_Pos)
 #define UART_UARTLCR_H_SPS                UART_UARTLCR_H_SPS_Msk
 #define UART_UARTLCR_H_WLEN_Pos           5U
-#define UART_UARTLCR_H_WLEN_Msk           (1U << UART_UARTLCR_H_WLEN_Pos)
+#define UART_UARTLCR_H_WLEN_Msk           (3U << UART_UARTLCR_H_WLEN_Pos)
 #define UART_UARTLCR_H_WLEN(n)            ((n) << UART_UARTLCR_H_WLEN_Pos)
 #define UART_UARTLCR_H_WLEN_5BITS         UART_UARTLCR_H_WLEN(0U)
 #define UART_UARTLCR_H_WLEN_6BITS         UART_UARTLCR_H_WLEN(1U)
@@ -2549,7 +2549,7 @@ typedef struct {
 #define WATCHDOG_REASON_TIMER             WATCHDOG_REASON_TIMER_Msk
 
 #define WATCHDOG_TICK_COUNT_Pos           11U
-#define WATCHDOG_TICK_COUNT_Msk           (0xFF800U << WATCHDOG_TICK_COUNT_Pos)
+#define WATCHDOG_TICK_COUNT_Msk           (0x1FFU << WATCHDOG_TICK_COUNT_Pos)
 #define WATCHDOG_TICK_COUNT               WATCHDOG_TICK_COUNT_Msk
 #define WATCHDOG_TICK_RUNNING_Pos         10U
 #define WATCHDOG_TICK_RUNNING_Msk         (1U << WATCHDOG_TICK_RUNNING_Pos)
@@ -2857,7 +2857,7 @@ typedef struct {
 #define I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Msk               (0xFFU << I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Pos)
 #define I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD                   I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Msk
 #define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos               0U
-#define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk               (0xFFU << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos)
+#define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk               (0xFFFFU << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos)
 #define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD                   I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk
 
 #define I2C_IC_TX_ABRT_SOURCE_TX_FLUSH_CNT_Pos           23U
@@ -2955,7 +2955,7 @@ typedef struct {
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Pos          16U
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Msk          (0xFFU << I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Pos)
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH              I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Msk
-#define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos          0U
+#define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos          8U
 #define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Msk          (0xFFU << I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos)
 #define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH              I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Msk
 


### PR DESCRIPTION
Four field definitions in `os/common/ext/RP/RP2040/rp2040.h` do not match the hardware, found by comparing the header against Raspberry Pi's generated RP2040 definitions:

- UART `UARTLCR_H.WLEN` is a two-bit field at bits 6:5 (datasheet table 432); the mask covered only bit 5. The `WLEN_nBITS` value macros were already correct.
- WATCHDOG `TICK.COUNT` applied the position shift to an already-positioned mask value; the field is nine bits at 19:11, mask `0x000ff800` (table 550).
- I2C `IC_SDA_HOLD.IC_SDA_TX_HOLD` is sixteen bits, not eight (table 481). The I2C driver uses this as a write mask; hold counts computed from supported system clocks stay below 256, so the old mask was wrong but not practically observable.
- I2C `IC_COMP_PARAM_1.RX_BUFFER_DEPTH` sits at bits 15:8, not 7:0 (table 492).

No in-tree code relied on the old values (`WLEN_8BITS` derives from the value macro, not the mask; the TICK_COUNT and RX_BUFFER_DEPTH macros are unused by drivers).

Verified: the RT-RP2040-PICO demo builds cleanly with the change, and on a Raspberry Pi Pico the corrected TICK_COUNT mask decodes `WATCHDOG.TICK.COUNT` as a live 0-11 counter (the old double-shifted mask always extracted zero) while UART output is unaffected.