### PR TITLE
ARMv6-M RP2: compile SMP support source out of non-SMP builds

### DIFF
--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -26,6 +26,11 @@
 
 #include "ch.h"
 
+/* This translation unit is always listed by port_rp2.mk, but its contents
+   depend on definitions made available only when the kernel is configured
+   for SMP; it compiles to nothing in a non-SMP configuration.*/
+#if (CH_CFG_SMP_MODE == TRUE) || defined(__DOXYGEN__)
+
 /*===========================================================================*/
 /* Module local definitions.                                                 */
 /*===========================================================================*/
@@ -168,5 +173,7 @@ void __port_spinlock_release(void) {
 
   port_spinlock_release();
 }
+
+#endif /* CH_CFG_SMP_MODE == TRUE */
 
 /** @} */


### PR DESCRIPTION
`port_rp2.mk` unconditionally lists `chcoresmp.c`, but the definitions it depends on (`PORT_FIFO_PANIC_MESSAGE`, the spinlock and SMP timer helpers) are made available only when the kernel is configured for SMP, so an RP2 port build with `CH_CFG_SMP_MODE == FALSE` fails to compile:

```
chcoresmp.c: In function 'Vector80':
chcoresmp.c:108:20: error: 'PORT_FIFO_PANIC_MESSAGE' undeclared
```

The whole translation unit is now guarded by `CH_CFG_SMP_MODE` (with the usual `__DOXYGEN__` exception) and compiles to nothing in a non-SMP configuration. Nothing references the compiled-out symbols in that configuration: `chcore.c` only calls `port_smp_init()` when the macro is defined, and it is only defined when `chcoresmp.h` is included in SMP mode.

Verified on this tree: the forced non-SMP build above compiles cleanly with the guard (with `CH_CFG_USE_TM` disabled, whose rejection in non-SMP is the kernel's own correct diagnostic since the plain ARMv6-M port has no RT counter), and the RT-RP2040-PICO SMP demo builds unchanged. The equivalent single-core configuration has also been run on a Raspberry Pi Pico.